### PR TITLE
Make callbacks use correct number of arguments

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -17,7 +17,7 @@ var constants = process.binding('constants');
  * @param {function()} func Function to call.
  * @return {*} Return (if callback is not provided).
  */
-function maybeCallback(callback, thisArg, func) {
+function maybeCallback(callback, thisArg, returns, func) {
   if (callback) {
     var err = null;
     var val;
@@ -27,7 +27,11 @@ function maybeCallback(callback, thisArg, func) {
       err = e;
     }
     process.nextTick(function() {
-      callback(err, val);
+      if (returns) {
+        callback(err, val);
+      } else {
+        callback(err);
+      };
     });
   } else {
     return func.call(thisArg);
@@ -215,7 +219,7 @@ Binding.prototype._untrackDescriptorById = function(fd) {
  * @return {Stats|undefined} Stats or undefined (if sync).
  */
 Binding.prototype.stat = function(filepath, callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, true, function() {
     var item = this._system.getItem(filepath);
     if (item instanceof SymbolicLink) {
       item = this._system.getItem(
@@ -236,7 +240,7 @@ Binding.prototype.stat = function(filepath, callback) {
  * @return {Stats|undefined} Stats or undefined (if sync).
  */
 Binding.prototype.fstat = function(fd, callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, true, function() {
     var descriptor = this._getDescriptorById(fd);
     var item = descriptor.getItem();
     return new Stats(item.getStats());
@@ -250,7 +254,7 @@ Binding.prototype.fstat = function(fd, callback) {
  * @param {function(Error)} callback Callback (optional).
  */
 Binding.prototype.close = function(fd, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     this._untrackDescriptorById(fd);
   });
 };
@@ -265,7 +269,7 @@ Binding.prototype.close = function(fd, callback) {
  * @return {string} File descriptor (if sync).
  */
 Binding.prototype.open = function(pathname, flags, mode, callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, true, function() {
     var descriptor = new FileDescriptor(flags);
     var item = this._system.getItem(pathname);
     if (item instanceof SymbolicLink) {
@@ -326,7 +330,7 @@ Binding.prototype.open = function(pathname, flags, mode, callback) {
  */
 Binding.prototype.read = function(fd, buffer, offset, length, position,
     callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, true, function() {
     var descriptor = this._getDescriptorById(fd);
     if (!descriptor.isRead()) {
       throw new FSError('EBADF');
@@ -363,7 +367,7 @@ Binding.prototype.read = function(fd, buffer, offset, length, position,
  */
 Binding.prototype.writeBuffer = function(fd, buffer, offset, length, position,
     callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, true, function() {
     var descriptor = this._getDescriptorById(fd);
     if (!descriptor.isWrite()) {
       throw new FSError('EBADF');
@@ -439,7 +443,7 @@ Binding.prototype.writeString = function(fd, string, position, encoding,
  * @return {undefined}
  */
 Binding.prototype.rename = function(oldPath, newPath, callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, false, function() {
     var oldItem = this._system.getItem(oldPath);
     if (!oldItem) {
       throw new FSError('ENOENT', oldPath);
@@ -486,7 +490,7 @@ Binding.prototype.rename = function(oldPath, newPath, callback) {
  * @return {Array.<string>} Array of items in directory (if sync).
  */
 Binding.prototype.readdir = function(dirpath, callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, true, function() {
     var dir = this._system.getItem(dirpath);
     if (!dir) {
       throw new FSError('ENOENT', dirpath);
@@ -506,7 +510,7 @@ Binding.prototype.readdir = function(dirpath, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.mkdir = function(pathname, mode, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var item = this._system.getItem(pathname);
     if (item) {
       throw new FSError('EEXIST', pathname);
@@ -530,7 +534,7 @@ Binding.prototype.mkdir = function(pathname, mode, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.rmdir = function(pathname, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var item = this._system.getItem(pathname);
     if (!item) {
       throw new FSError('ENOENT', pathname);
@@ -554,7 +558,7 @@ Binding.prototype.rmdir = function(pathname, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.ftruncate = function(fd, len, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var descriptor = this._getDescriptorById(fd);
     if (!descriptor.isWrite()) {
       throw new FSError('EINVAL');
@@ -588,7 +592,7 @@ Binding.prototype.truncate = Binding.prototype.ftruncate;
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.chown = function(pathname, uid, gid, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var item = this._system.getItem(pathname);
     if (!item) {
       throw new FSError('ENOENT', pathname);
@@ -607,7 +611,7 @@ Binding.prototype.chown = function(pathname, uid, gid, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.fchown = function(fd, uid, gid, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var descriptor = this._getDescriptorById(fd);
     var item = descriptor.getItem();
     item.setUid(uid);
@@ -623,7 +627,7 @@ Binding.prototype.fchown = function(fd, uid, gid, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.chmod = function(pathname, mode, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var item = this._system.getItem(pathname);
     if (!item) {
       throw new FSError('ENOENT', pathname);
@@ -640,7 +644,7 @@ Binding.prototype.chmod = function(pathname, mode, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.fchmod = function(fd, mode, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var descriptor = this._getDescriptorById(fd);
     var item = descriptor.getItem();
     item.setMode(mode);
@@ -654,7 +658,7 @@ Binding.prototype.fchmod = function(fd, mode, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.unlink = function(pathname, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var item = this._system.getItem(pathname);
     if (!item) {
       throw new FSError('ENOENT', pathname);
@@ -676,7 +680,7 @@ Binding.prototype.unlink = function(pathname, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.utimes = function(pathname, atime, mtime, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var item = this._system.getItem(pathname);
     if (!item) {
       throw new FSError('ENOENT', pathname);
@@ -695,7 +699,7 @@ Binding.prototype.utimes = function(pathname, atime, mtime, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.futimes = function(fd, atime, mtime, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var descriptor = this._getDescriptorById(fd);
     var item = descriptor.getItem();
     item.setATime(new Date(atime * 1000));
@@ -710,7 +714,7 @@ Binding.prototype.futimes = function(fd, atime, mtime, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.fsync = function(fd, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     this._getDescriptorById(fd);
   });
 };
@@ -722,7 +726,7 @@ Binding.prototype.fsync = function(fd, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.fdatasync = function(fd, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     this._getDescriptorById(fd);
   });
 };
@@ -735,7 +739,7 @@ Binding.prototype.fdatasync = function(fd, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.link = function(srcPath, destPath, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     var item = this._system.getItem(srcPath);
     if (!item) {
       throw new FSError('ENOENT', srcPath);
@@ -766,7 +770,7 @@ Binding.prototype.link = function(srcPath, destPath, callback) {
  * @param {function(Error)} callback Optional callback.
  */
 Binding.prototype.symlink = function(srcPath, destPath, type, callback) {
-  maybeCallback(callback, this, function() {
+  maybeCallback(callback, this, false, function() {
     if (this._system.getItem(destPath)) {
       throw new FSError('EEXIST', destPath);
     }
@@ -791,7 +795,7 @@ Binding.prototype.symlink = function(srcPath, destPath, type, callback) {
  * @return {string} Symbolic link contents (path to source).
  */
 Binding.prototype.readlink = function(pathname, callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, true, function() {
     var link = this._system.getItem(pathname);
     if (!(link instanceof SymbolicLink)) {
       throw new FSError('EINVAL', pathname);
@@ -808,7 +812,7 @@ Binding.prototype.readlink = function(pathname, callback) {
  * @return {Stats|undefined} Stats or undefined (if sync).
  */
 Binding.prototype.lstat = function(filepath, callback) {
-  return maybeCallback(callback, this, function() {
+  return maybeCallback(callback, this, true, function() {
     var item = this._system.getItem(filepath);
     if (!item) {
       throw new FSError('ENOENT', filepath);


### PR DESCRIPTION
In the functions where 'fs' gives a callback of the form function(err),
mock-fs will give a callback of the form function(err, undefined). This
is not equivalent, and will mean using mock-fs functions in place like
some of async.js flow control functions will cause a different behaviour
than the native 'fs' functions.

See https://gist.github.com/bruse/5e5ba24bc5109090f75b for an example
of this inconsistent behavior.

This is one way of fixing it. If we are always sure that the functions that
are supposed to return data never returns undefined, we can make it a
lot shorter I suppose, but I chose to be explicit.

What do you think?
