### PR TITLE
Only call callback with two args if return is undefined

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -27,7 +27,11 @@ function maybeCallback(callback, thisArg, func) {
       err = e;
     }
     process.nextTick(function() {
-      callback(err, val);
+      if (val === undefined) {
+        callback(err);
+      } else {
+        callback(err, val);
+      }
     });
   } else {
     return func.call(thisArg);

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -1637,6 +1637,20 @@ describe('Mocking the file system', function() {
       });
     });
 
+    it('calls callback with a single argument on success', function(done) {
+      fs.mkdir('parent/arity', function(err) {
+        assert.equal(arguments.length, 1);
+        done();
+      });
+    });
+
+    it('calls callback with a single argument on failure', function(done) {
+      fs.mkdir('parent', function(err) {
+        assert.instanceOf(err, Error);
+        done();
+      });
+    });
+
   });
 
   describe('fs.mkdirSync(path, [mode])', function() {


### PR DESCRIPTION
This makes `mock-fs` work with modules that check the function arity (e.g. `async`).

Thanks @bruse for finding the issue and providing the [test case](https://gist.github.com/bruse/5e5ba24bc5109090f75b).  Fixes #10.
