### PR TITLE
Document support for Node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.11"
+  - "0.12"
   - "0.10"
   - "0.8"
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.4.0
+
+ * Support for Node 0.12 (thanks @mlegenhausen see [#18][#18]).
+
 ## 2.3.1
 
  * Preserve arity of callbacks (see [#11][#11]).
@@ -43,3 +47,4 @@
 [#7]: https://github.com/tschaub/mock-fs/pull/7
 [#9]: https://github.com/tschaub/mock-fs/issues/9
 [#11]: https://github.com/tschaub/mock-fs/pull/11
+[#18]: https://github.com/tschaub/mock-fs/pull/18

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,6 @@ Mock file access is controlled based on file mode where `process.getuid()` and `
 
 The following `fs` functions are *not* currently mocked (if your tests use these, they will work against the real file system): `fs.FSWatcher`, `fs.unwatchFile`, `fs.watch`, and `fs.watchFile`.  Pull requests welcome.
 
-Tested on Linux, OSX, and Windows using Node 0.8, 0.9, 0.10, and 0.11.  Check the tickets for a list of [known issues](https://github.com/tschaub/mock-fs/issues).
+Tested on Linux, OSX, and Windows using Node 0.8, 0.9, 0.10, 0.11, and 0.12.  Check the tickets for a list of [known issues](https://github.com/tschaub/mock-fs/issues).
 
 [![Current Status](https://secure.travis-ci.org/tschaub/mock-fs.png?branch=master)](https://travis-ci.org/tschaub/mock-fs)


### PR DESCRIPTION
This adds docs and adds 0.12 to the list for Travis.