### PR TITLE
Add support for birthtime

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -190,6 +190,9 @@ FileSystem.file = function(config) {
     if (config.hasOwnProperty('mtime')) {
       file.setMTime(config.mtime);
     }
+    if (config.hasOwnProperty('birthtime')) {
+      file.setBirthtime(config.birthtime);
+    }
     return file;
   };
 };
@@ -229,6 +232,9 @@ FileSystem.symlink = function(config) {
     if (config.hasOwnProperty('mtime')) {
       link.setMTime(config.mtime);
     }
+    if (config.hasOwnProperty('birthtime')) {
+      link.setBirthtime(config.birthtime);
+    }
     return link;
   };
 };
@@ -265,6 +271,9 @@ FileSystem.directory = function(config) {
     }
     if (config.hasOwnProperty('mtime')) {
       dir.setMTime(config.mtime);
+    }
+    if (config.hasOwnProperty('birthtime')) {
+      dir.setBirthtime(config.birthtime);
     }
     return dir;
   };

--- a/lib/item.js
+++ b/lib/item.js
@@ -52,6 +52,12 @@ function Item() {
   this._ctime = new Date(now);
 
   /**
+   * Birth time.
+   * @type {Date}
+   */
+  this._birthtime = new Date(now);
+
+  /**
    * Modification time.
    * @type {Date}
    */
@@ -188,6 +194,24 @@ Item.prototype.setCTime = function(ctime) {
 
 
 /**
+ * Get birth time.
+ * @return {Date} Birth time.
+ */
+Item.prototype.getBirthtime = function() {
+  return this._birthtime;
+};
+
+
+/**
+ * Set change time.
+ * @param {Date} birthtime Birth time.
+ */
+Item.prototype.setBirthtime = function(birthtime) {
+  this._birthtime = birthtime;
+};
+
+
+/**
  * Get modification time.
  * @return {Date} Modification time.
  */
@@ -277,7 +301,8 @@ Item.prototype.getStats = function() {
     ino: this._id,
     atime: this.getATime(),
     mtime: this.getMTime(),
-    ctime: this.getCTime()
+    ctime: this.getCTime(),
+    birthtime: this.getBirthtime()
   };
 };
 

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ Create a factory for new files.  Supported properties:
  * **atime** - `Date` The last file access time.  Defaults to `new Date()`.  Updated when file contents are accessed.
  * **ctime** - `Date` The last file change time.  Defaults to `new Date()`.  Updated when file owner or permissions change.
  * **mtime** - `Date` The last file modification time.  Defaults to `new Date()`.  Updated when file contents change.
+ * **birthtime** - `Date` The time of file creation.  Defaults to `new Date()`.
 
 To create a mock filesystem with a very old file named `foo`, you could do something like this:
 ```js
@@ -104,6 +105,7 @@ Create a factory for new directories.  Supported properties:
  * **atime** - `Date` The last directory access time.  Defaults to `new Date()`.
  * **ctime** - `Date` The last directory change time.  Defaults to `new Date()`.  Updated when owner or permissions change.
  * **mtime** - `Date` The last directory modification time.  Defaults to `new Date()`.  Updated when an item is added, removed, or renamed.
+ * **birthtime** - `Date` The time of directory creation.  Defaults to `new Date()`.
  * **items** - `Object` Directory contents.  Members will generate additional files, directories, or symlinks.
 
 To create a mock filesystem with a directory with the relative path `some/dir` that has a mode of `0755` and a couple child files, you could do something like this:
@@ -136,6 +138,7 @@ Create a factory for new symlinks.  Supported properties:
  * **atime** - `Date` The last symlink access time.  Defaults to `new Date()`.
  * **ctime** - `Date` The last symlink change time.  Defaults to `new Date()`.
  * **mtime** - `Date` The last symlink modification time.  Defaults to `new Date()`.
+ * **birthtime** - `Date` The time of symlink creation.  Defaults to `new Date()`.
 
 To create a mock filesystem with a file and a symlink, you could do something like this:
 ```js
@@ -184,7 +187,7 @@ When you require `mock-fs`, Node's own `fs` module is patched to allow the bindi
 
 The following [`fs` functions](http://nodejs.org/api/fs.html) are overridden: `fs.ReadStream`, `fs.Stats`, `fs.WriteStream`, `fs.appendFile`, `fs.appendFileSync`, `fs.chmod`, `fs.chmodSync`, `fs.chown`, `fs.chownSync`, `fs.close`, `fs.closeSync`, `fs.createReadStream`, `fs.createWriteStream`, `fs.exists`, `fs.existsSync`, `fs.fchmod`, `fs.fchmodSync`, `fs.fchown`, `fs.fchownSync`, `fs.fdatasync`, `fs.fdatasyncSync`, `fs.fstat`, `fs.fstatSync`, `fs.fsync`, `fs.fsyncSync`, `fs.ftruncate`, `fs.ftruncateSync`, `fs.futimes`, `fs.futimesSync`, `fs.lchmod`, `fs.lchmodSync`, `fs.lchown`, `fs.lchownSync`, `fs.link`, `fs.linkSync`, `fs.lstatSync`, `fs.lstat`, `fs.mkdir`, `fs.mkdirSync`, `fs.open`, `fs.openSync`, `fs.read`, `fs.readSync`, `fs.readFile`, `fs.readFileSync`, `fs.readdir`, `fs.readdirSync`, `fs.readlink`, `fs.readlinkSync`, `fs.realpath`, `fs.realpathSync`, `fs.rename`, `fs.renameSync`, `fs.rmdir`, `fs.rmdirSync`, `fs.stat`, `fs.statSync`, `fs.symlink`, `fs.symlinkSync`, `fs.truncate`, `fs.truncateSync`, `fs.unlink`, `fs.unlinkSync`, `fs.utimes`, `fs.utimesSync`, `fs.write`, `fs.writeSync`, `fs.writeFile`, and `fs.writeFileSync`.
 
-Mock `fs.Stats` objects have the following properties: `dev`, `ino`, `nlink`, `mode`, `size`, `rdev`, `blksize`, `blocks`, `atime`, `ctime`, `mtime`, `uid`, and `gid`.  In addition, all of the `is*()` method are provided (e.g. `isDirectory()`, `isFile()`, et al.).
+Mock `fs.Stats` objects have the following properties: `dev`, `ino`, `nlink`, `mode`, `size`, `rdev`, `blksize`, `blocks`, `atime`, `ctime`, `mtime`, `birthtime`, `uid`, and `gid`.  In addition, all of the `is*()` method are provided (e.g. `isDirectory()`, `isFile()`, et al.).
 
 Mock file access is controlled based on file mode where `process.getuid()` and `process.getgid()` are available (POSIX systems).  On other systems (e.g. Windows) the file mode has no effect.
 

--- a/test/lib/binding.spec.js
+++ b/test/lib/binding.spec.js
@@ -26,7 +26,8 @@ describe('Binding', function() {
           mode: parseInt('0644', 8),
           atime: new Date(1),
           ctime: new Date(2),
-          mtime: new Date(3)
+          mtime: new Date(3),
+          birthtime: new Date(4)
         }),
         'one-link.txt': FileSystem.symlink({path: './one.txt'}),
         'three.bin': new Buffer([1, 2, 3]),
@@ -119,7 +120,7 @@ describe('Binding', function() {
       assert.equal(stats.mode & constants.S_IFMT, constants.S_IFDIR);
     });
 
-    it('includes atime, ctime, and mtime', function(done) {
+    it('includes atime, ctime, mtime and birthtime', function(done) {
       var binding = new Binding(system);
       binding.stat(path.join('mock-dir', 'two.txt'), function(err, stats) {
         if (err) {
@@ -128,6 +129,7 @@ describe('Binding', function() {
         assert.equal(stats.atime.getTime(), new Date(1).getTime());
         assert.equal(stats.ctime.getTime(), new Date(2).getTime());
         assert.equal(stats.mtime.getTime(), new Date(3).getTime());
+        assert.equal(stats.birthtime.getTime(), new Date(4).getTime());
         done();
       });
     });

--- a/test/lib/item.spec.js
+++ b/test/lib/item.spec.js
@@ -60,6 +60,28 @@ describe('Item', function() {
 
   });
 
+  describe('#getBirthtime()', function() {
+
+    it('returns a date', function() {
+      var item = new Item();
+      var date = item.getBirthtime();
+      assert.instanceOf(date, Date);
+      assert.isTrue(date <= new Date());
+    });
+
+  });
+
+  describe('#setBirthtime()', function() {
+
+    it('sets the birthtime', function() {
+      var item = new Item();
+      var date = new Date();
+      item.setBirthtime(date);
+      assert.equal(item.getBirthtime(), date);
+    });
+
+  });
+
   describe('#getMTime()', function() {
 
     it('returns a date', function() {


### PR DESCRIPTION
In issue #31 I reported that since node 0.11 the ```fs.Stats``` call would return a ```birthtime``` property that specified the initial creation time of the item.

This patch seems to match existing behavior where the virtual file system matches that of the latest version of node regardless of which version of node it is actually running on (for example, Stats always returns a blksize which was also only introduced in 0.11).

Thanks,