### PR TITLE
Mock process.cwd and process.chdir methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var semver = require('semver');
 
 var Binding = require('./binding');
 var FileSystem = require('./filesystem');
+var FSError = require('./error');
 
 var versions = {
   '0.8.x': 'fs-0.8.26.js',
@@ -48,10 +49,19 @@ for (var name in mockFs) {
     realFs[name] = mockFs[name];
   }
 }
+var originalProcess = {
+  cwd: process.cwd,
+  chdir: process.chdir
+};
 
 function setBinding(binding, Stats) {
   mockFs.__set__('binding', binding);
   mockFs.Stats = realFs.Stats = Stats;
+}
+
+function setProcess(cwd, chdir) {
+  process.cwd = cwd;
+  process.chdir = chdir;
 }
 
 
@@ -63,6 +73,19 @@ var exports = module.exports = function mock(config) {
   var system = FileSystem.create(config);
   var binding = new Binding(system);
   setBinding(binding, binding.Stats);
+
+  var currentPath = process.cwd();
+  setProcess(
+    function cwd() {
+      return currentPath;
+    },
+    function chdir(directory) {
+      if (!mockFs.statSync(directory).isDirectory()) {
+        throw new FSError('ENOTDIR');
+      }
+      currentPath = path.resolve(currentPath, directory);
+    }
+  );
 };
 
 
@@ -71,6 +94,7 @@ var exports = module.exports = function mock(config) {
  */
 exports.restore = function() {
   setBinding(originalBinding, originalStats);
+  setProcess(originalProcess.cwd, originalProcess.chdir);
 };
 
 

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -2519,6 +2519,96 @@ describe('Mocking the file system', function() {
 
   });
 
+  describe('process.cwd()', function() {
+
+    afterEach(mock.restore);
+
+    it('maintains current working directory', function() {
+
+      var originalCwd = process.cwd();
+      mock();
+
+      var cwd = process.cwd();
+      assert.equal(cwd, originalCwd);
+
+    });
+
+    it('allows changing directory', function() {
+
+      var originalCwd = process.cwd();
+      mock({
+        'dir': {}
+      });
+
+      process.chdir('dir');
+      var cwd = process.cwd();
+      assert.equal(cwd, path.join(originalCwd, 'dir'));
+ 
+    });
+
+    it('prevents changing directory to non-existent path', function() {
+
+      var originalCwd = process.cwd();
+      mock();
+
+      var err;
+      try {
+        process.chdir('dir');
+      } catch (e) {
+        err = e;
+      }
+      assert.instanceOf(err, Error);
+      assert.equal(err.code, 'ENOENT');
+
+    });
+
+    it('prevents changing directory to non-directory path', function() {
+
+      var originalCwd = process.cwd();
+      mock({
+        'file': ''
+      });
+
+      var err;
+      try {
+        process.chdir('file');
+      } catch (e) {
+        err = e;
+      }
+      assert.instanceOf(err, Error);
+      assert.equal(err.code, 'ENOTDIR');
+
+    });
+
+    it('restores original methods on restore', function() {
+
+      var originalCwd = process.cwd;
+      var originalChdir = process.chdir;
+      mock();
+
+      mock.restore();
+      assert.equal(process.cwd, originalCwd);
+      assert.equal(process.chdir, originalChdir);
+
+    });
+
+    it('restores original working directory on restore', function() {
+
+      var originalCwd = process.cwd();
+      mock({
+        'dir': {}
+      });
+
+      process.chdir('dir');
+      mock.restore();
+
+      var cwd = process.cwd();
+      assert.equal(cwd, originalCwd);
+
+    });
+
+  });
+
   if (process.getuid && process.getgid) {
 
     describe('security', function() {


### PR DESCRIPTION
Hi there - thanks for a great library!

The only problem I had with it was that the `process.cwd()` and `process.chdir()` methods still act on the real filesystem, rather than the mock filesystem. This pull request means that these methods get mocked along with the filesystem bindings, ensuring that `process` is kept in sync with `fs`.

A couple of points to note:

- I've tried to match the code style to what's around it, but let me know if there's any formatting/naming/etc conventions that I've missed
- I'm pretty new to testing so I'm not sure how well I've written the tests

Let me know if this is all ok!