### PR TITLE
Add blurb to readme re: graceful-fs and gulp compat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,13 @@ npm install mock-fs --save-dev
 
 ## Caveats
 
+### Using with other modules that modify `fs`
+
 When you require `mock-fs`, Node's own `fs` module is patched to allow the binding to the underlying file system to be swapped out.  If you require `mock-fs` *before* any other modules that modify `fs` (e.g. `graceful-fs`), the mock should behave as expected.
+
+**Note** `mock-fs` is not compatible with `graceful-fs >= 3.0.0` and therefore not compatible with `gulp >= 3.7.0`. 
+
+### `fs` overrides
 
 The following [`fs` functions](http://nodejs.org/api/fs.html) are overridden: `fs.ReadStream`, `fs.Stats`, `fs.WriteStream`, `fs.appendFile`, `fs.appendFileSync`, `fs.chmod`, `fs.chmodSync`, `fs.chown`, `fs.chownSync`, `fs.close`, `fs.closeSync`, `fs.createReadStream`, `fs.createWriteStream`, `fs.exists`, `fs.existsSync`, `fs.fchmod`, `fs.fchmodSync`, `fs.fchown`, `fs.fchownSync`, `fs.fdatasync`, `fs.fdatasyncSync`, `fs.fstat`, `fs.fstatSync`, `fs.fsync`, `fs.fsyncSync`, `fs.ftruncate`, `fs.ftruncateSync`, `fs.futimes`, `fs.futimesSync`, `fs.lchmod`, `fs.lchmodSync`, `fs.lchown`, `fs.lchownSync`, `fs.link`, `fs.linkSync`, `fs.lstatSync`, `fs.lstat`, `fs.mkdir`, `fs.mkdirSync`, `fs.open`, `fs.openSync`, `fs.read`, `fs.readSync`, `fs.readFile`, `fs.readFileSync`, `fs.readdir`, `fs.readdirSync`, `fs.readlink`, `fs.readlinkSync`, `fs.realpath`, `fs.realpathSync`, `fs.rename`, `fs.renameSync`, `fs.rmdir`, `fs.rmdirSync`, `fs.stat`, `fs.statSync`, `fs.symlink`, `fs.symlinkSync`, `fs.truncate`, `fs.truncateSync`, `fs.unlink`, `fs.unlinkSync`, `fs.utimes`, `fs.utimesSync`, `fs.write`, `fs.writeSync`, `fs.writeFile`, and `fs.writeFileSync`.
 


### PR DESCRIPTION
Changes:

1. Added some h3 to split up caveats section
2. Added note about mock-fs not working with graceful-fs 3.0.0+ and gulp 3.7.0+

As far as I can tell gulp 3.6.x works fine with mock-fs.

- In [gulp 3.7.0](https://github.com/gulpjs/gulp/commit/2ae97419ad69c279b3e98533992aa9b9f3e6853e#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) the dep on vinyl-fs changed from `^0.1.3` to `^0.2.0`.
- In [vinyl-fs 0.2.1](https://github.com/wearefractal/vinyl-fs/commit/c9b2c075dbb55ee97cd6ab9909bd1e1f87bf77e0) the dep on graceful-fs changed from `^2.0.1` to `^3.0.0`.
- graceful-fs 3.0.0 is where compatibility broke

Relevant issues: #42, #44