### PR TITLE
Handle links to symlinks in FileSystem#getItem()

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -494,10 +494,11 @@ Binding.prototype.rename = function(oldPath, newPath, callback) {
  */
 Binding.prototype.readdir = function(dirpath, callback) {
   return maybeCallback(callback, this, function() {
+    var dpath = dirpath;
     var dir = this._system.getItem(dirpath);
-    if (dir instanceof SymbolicLink) {
-      dir = this._system.getItem(
-          path.resolve(path.dirname(dirpath), dir.getPath()));
+    while (dir instanceof SymbolicLink) {
+      dpath = path.resolve(path.dirname(dpath), dir.getPath());
+      dir = this._system.getItem(dpath);
     }
     if (!dir) {
       throw new FSError('ENOENT', dirpath);

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -74,22 +74,25 @@ FileSystem.prototype.getItem = function(filepath) {
   var currentParts = getPathParts(process.cwd());
   var item = this._root;
   var itemPath = '/';
-  var linkPath;
   var name;
   for (var i = 0, ii = parts.length; i < ii; ++i) {
     name = parts[i];
-    if (item instanceof SymbolicLink) {
-      // Symbolic link being traversed as a directory
-      linkPath = path.resolve(path.dirname(itemPath), item.getPath());
-      item = this.getItem(linkPath);
+    while (item instanceof SymbolicLink) {
+      // Symbolic link being traversed as a directory --- If link targets
+      // another symbolic link, resolve target's path relative to the original
+      // link's target, otherwise relative to the current item.
+      itemPath = path.resolve(path.dirname(itemPath), item.getPath());
+      item = this.getItem(itemPath);
     }
-    if (item instanceof Directory && name !== currentParts[i]) {
-      // make sure traversal is allowed
-      if (!item.canExecute()) {
-        throw new FSError('EACCES', filepath);
+    if (item) {
+      if (item instanceof Directory && name !== currentParts[i]) {
+        // make sure traversal is allowed
+        if (!item.canExecute()) {
+          throw new FSError('EACCES', filepath);
+        }
       }
+      item = item.getItem(name);
     }
-    item = item.getItem(name);
     if (!item) {
       break;
     }

--- a/test/lib/binding.spec.js
+++ b/test/lib/binding.spec.js
@@ -31,6 +31,7 @@ describe('Binding', function() {
           birthtime: new Date(4)
         }),
         'one-link.txt': FileSystem.symlink({path: './one.txt'}),
+        'one-link2.txt': FileSystem.symlink({path: './one-link.txt'}),
         'three.bin': new Buffer([1, 2, 3]),
         'empty': {},
         'non-empty': {
@@ -45,6 +46,7 @@ describe('Binding', function() {
           'b.txt': 'b content'
         },
         'dir-link': FileSystem.symlink({path: './non-empty'}),
+        'dir-link2': FileSystem.symlink({path: './dir-link'}),
         'dead-link': FileSystem.symlink({path: './non-a-real-file'})
       }
     });
@@ -325,8 +327,9 @@ describe('Binding', function() {
         assert.isNull(err);
         assert.isArray(items);
         assert.deepEqual(items.sort(),
-            ['dead-link', 'dir-link', 'empty', 'non-empty', 'one-link.txt',
-                'one.txt', 'three.bin', 'two.txt']);
+            ['dead-link', 'dir-link', 'dir-link2', 'empty', 'non-empty',
+                'one-link.txt', 'one-link2.txt', 'one.txt', 'three.bin',
+                'two.txt']);
         done();
       });
     });
@@ -336,13 +339,25 @@ describe('Binding', function() {
       var items = binding.readdir('mock-dir');
       assert.isArray(items);
       assert.deepEqual(items.sort(),
-          ['dead-link', 'dir-link', 'empty', 'non-empty', 'one-link.txt',
-              'one.txt', 'three.bin', 'two.txt']);
+          ['dead-link', 'dir-link', 'dir-link2', 'empty', 'non-empty',
+              'one-link.txt', 'one-link2.txt', 'one.txt', 'three.bin',
+              'two.txt']);
     });
 
     it('calls callback with file list for symbolic linked dir', function(done) {
       var binding = new Binding(system);
       binding.readdir(path.join('mock-dir', 'dir-link'), function(err, items) {
+        assert.isNull(err);
+        assert.isArray(items);
+        assert.deepEqual(items.sort(), ['a.txt', 'b.txt']);
+        done();
+      });
+    });
+
+    it('calls callback with file list for link to symbolic linked dir',
+        function(done) {
+      var binding = new Binding(system);
+      binding.readdir(path.join('mock-dir', 'dir-link2'), function(err, items) {
         assert.isNull(err);
         assert.isArray(items);
         assert.deepEqual(items.sort(), ['a.txt', 'b.txt']);
@@ -388,6 +403,17 @@ describe('Binding', function() {
     it('calls callback with error for symbolic link to file', function(done) {
       var binding = new Binding(system);
       binding.readdir(path.join('mock-dir', 'one-link.txt'),
+          function(err, items) {
+        assert.instanceOf(err, Error);
+        assert.isUndefined(items);
+        done();
+      });
+    });
+
+    it('calls callback with error for link to symbolic link to file',
+        function(done) {
+      var binding = new Binding(system);
+      binding.readdir(path.join('mock-dir', 'one-link2.txt'),
           function(err, items) {
         assert.instanceOf(err, Error);
         assert.isUndefined(items);
@@ -779,8 +805,9 @@ describe('Binding', function() {
       var items = binding.readdir(newPath);
       assert.isArray(items);
       assert.deepEqual(items.sort(),
-          ['dead-link', 'dir-link', 'empty', 'non-empty', 'one-link.txt',
-              'one.txt', 'three.bin', 'two.txt']);
+          ['dead-link', 'dir-link', 'dir-link2', 'empty', 'non-empty',
+              'one-link.txt', 'one-link2.txt', 'one.txt', 'three.bin',
+              'two.txt']);
     });
 
     it('calls callback with error for bogus old path', function(done) {

--- a/test/lib/filesystem.spec.js
+++ b/test/lib/filesystem.spec.js
@@ -46,6 +46,30 @@ describe('FileSystem', function() {
 
     });
 
+    it('gets an item traversing links to symbolic links', function() {
+      var system = FileSystem.create({
+        'dir-link': FileSystem.symlink({path: './b/dir-link2'}),
+        'b': {
+          'dir-link2': FileSystem.symlink({path: './c/dir'}),
+          'c': {
+            dir: {
+              'a': 'file a',
+              'b': {
+                'c': 'file c',
+                'd': 'file d'
+              }
+            }
+          }
+        }
+      });
+      var file = system.getItem(path.join('dir-link', 'a'));
+      assert.instanceOf(file, File);
+
+      var dir = system.getItem(path.join('dir-link', 'b'));
+      assert.instanceOf(dir, Directory);
+      assert.deepEqual(dir.list().sort(), ['c', 'd']);
+    });
+
   });
 
 });


### PR DESCRIPTION
Further adjustment to this feature to make links to links work
correctly (at least for readdir and FS.getItem)