### PR TITLE
update rewire to 2.3.4 to allow for babel compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rimraf": "~2.2.6"
   },
   "dependencies": {
-    "rewire": "~2.0.0",
+    "rewire": "~2.3.4",
     "semver": "^4.2.0"
   }
 }


### PR DESCRIPTION
Rewire 2.3 handles globals better so that babel can compile it. https://github.com/jhnns/rewire/releases/tag/v2.3.0