### PR TITLE
new mock return with FileSystem

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,7 @@ function setProcess(cwd, chdir) {
 /**
  * Swap out the fs bindings for a mock file system.
  * @param {Object} config Mock file system configuration.
+ * @return {Object} A mock file system.
  */
 var exports = module.exports = function mock(config) {
   var system = FileSystem.create(config);

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ var exports = module.exports = function mock(config) {
       currentPath = path.resolve(currentPath, directory);
     }
   );
+  return system;
 };
 
 


### PR DESCRIPTION
New file system mock returns with the mocked file system. Useful if file creation should be verified (filesystem.getItem(...)...).