### PR TITLE
Add function constructor for files.

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -21,6 +21,12 @@ function File() {
    */
   this._content = EMPTY;
 
+  /**
+   * File size.
+   * @type {number}
+   */
+  this._size = undefined;
+
 }
 util.inherits(File, Item);
 
@@ -40,8 +46,28 @@ File.prototype.getContent = function() {
                        returning a string or buffer');
     }
     this._content = content;
+    this._size = content.length;
   }
   return this._content;
+};
+
+
+/**
+ * Set the file contents.
+ * @param {string|Buffer} content File contents.
+ */
+File.prototype.setContent = function(content) {
+  if (typeof content === 'string') {
+    content = new Buffer(content);
+  } else if (!Buffer.isBuffer(content) && !(typeof content === 'function')) {
+    throw new Error('File content must be a string, buffer, or function \
+                     returning a string or buffer');
+  }
+  this._content = content;
+  this._size = content.length;
+  var now = Date.now();
+  this.setCTime(new Date(now));
+  this.setMTime(new Date(now));
 };
 
 
@@ -68,7 +94,10 @@ File.prototype.setContent = function(content) {
  * @return {Object} Stats properties.
  */
 File.prototype.getStats = function() {
-  var size = this._content.length;
+  if (typeof this._size === 'undefined') {
+    this._size = this._content.length;
+  }
+  var size = this._size;
   var stats = Item.prototype.getStats.call(this);
   stats.mode = this.getMode() | constants.S_IFREG;
   stats.size = size;

--- a/lib/file.js
+++ b/lib/file.js
@@ -31,6 +31,16 @@ util.inherits(File, Item);
  */
 File.prototype.getContent = function() {
   this.setATime(new Date());
+  if (typeof this._content === 'function') {
+    var content = this._content();
+    if (typeof content === 'string') {
+      content = new Buffer(content);
+    } else if (!Buffer.isBuffer(content)) {
+      throw new Error('File content must be a string, buffer, or function \
+                       returning a string or buffer');
+    }
+    this._content = content;
+  }
   return this._content;
 };
 
@@ -42,8 +52,9 @@ File.prototype.getContent = function() {
 File.prototype.setContent = function(content) {
   if (typeof content === 'string') {
     content = new Buffer(content);
-  } else if (!Buffer.isBuffer(content)) {
-    throw new Error('File content must be a string or buffer');
+  } else if (!Buffer.isBuffer(content) && !(typeof content === 'function')) {
+    throw new Error('File content must be a string, buffer, or function \
+                     returning a string or buffer');
   }
   this._content = content;
   var now = Date.now();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mock-fs",
   "description": "A configurable mock file system.  You know, for testing.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "lib/index.js",
   "homepage": "https://github.com/tschaub/mock-fs",
   "author": {

--- a/test/lib/file.spec.js
+++ b/test/lib/file.spec.js
@@ -60,6 +60,26 @@ describe('File', function() {
       assert.equal(String(content), 'baz');
     });
 
+    it('accepts a function returning a string', function() {
+      var file = new File();
+      file.setContent(function() {
+        return 'foobar'
+      });
+      var content = file.getContent();
+      assert.isTrue(Buffer.isBuffer(content));
+      assert.equal(String(content), 'foobar');
+    });
+
+    it('accepts a function returning a buffer', function() {
+      var file = new File();
+      file.setContent(function() {
+        return new Buffer('quxbaz');
+      });
+      var content = file.getContent();
+      assert.isTrue(Buffer.isBuffer(content));
+      assert.equal(String(content), 'quxbaz');
+    });
+
     it('throws for other types', function() {
       assert.throws(function() {
         var file = new File();

--- a/test/lib/filesystem.spec.js
+++ b/test/lib/filesystem.spec.js
@@ -114,6 +114,19 @@ describe('FileSystem.file', function() {
     assert.equal(String(content), 'foo');
   });
 
+  it('accepts a content function', function() {
+    var factory = FileSystem.file({content: function() {
+      return 'bar';
+    }});
+    assert.isFunction(factory);
+
+    var file = factory();
+    assert.instanceOf(file, File);
+    var content = file.getContent();
+    assert.isTrue(Buffer.isBuffer(content));
+    assert.equal(String(content), 'bar');
+  });
+
 });
 
 
@@ -137,6 +150,9 @@ describe('FileSystem.create', function() {
     var system = FileSystem.create({
       'path/to/one': {
         'file.js': 'file.js content',
+        'async.file': FileSystem.file({content: function() {
+          return 'async.file content';
+        }}),
         'dir': {}
       },
       'path/to/two.js': 'two.js content',
@@ -151,13 +167,19 @@ describe('FileSystem.create', function() {
     filepath = path.join('path', 'to', 'one');
     item = system.getItem(filepath);
     assert.instanceOf(item, Directory);
-    assert.deepEqual(item.list().sort(), ['dir', 'file.js']);
+    assert.deepEqual(item.list().sort(), ['async.file', 'dir', 'file.js']);
 
     // confirm 'path/to/one/file.js' file was created
     filepath = path.join('path', 'to', 'one', 'file.js');
     item = system.getItem(filepath);
     assert.instanceOf(item, File);
     assert.equal(String(item.getContent()), 'file.js content');
+
+    // confirm 'path/to/one/async.file' file was created
+    filepath = path.join('path', 'to', 'one', 'async.file');
+    item = system.getItem(filepath);
+    assert.instanceOf(item, File);
+    assert.equal(String(item.getContent()), 'async.file content');
 
     // confirm 'path/to/one/dir' directory was created
     filepath = path.join('path', 'to', 'one', 'dir');


### PR DESCRIPTION
This lets files be populated async, e.g.: creating a mock overlay of a
live file system. The function may return `fs.readFile(...)`, pull a
buffer from S3 or GitHub, or arbitrary other IO actions to return a
string or Buffer.

This is not intended to allow populating directories async, it's assumed
that crawling directories is cheap relative to reading files.