### PR TITLE
Fix parent perms issues

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -567,6 +567,7 @@ Binding.prototype.mkdir = function(pathname, mode, callback) {
     if (!parent) {
       throw new FSError('ENOENT', pathname);
     }
+    this.access(path.dirname(pathname), parseInt('0002', 8));
     var dir = new Directory();
     if (mode) {
       dir.setMode(mode);
@@ -593,6 +594,7 @@ Binding.prototype.rmdir = function(pathname, callback) {
     if (item.list().length > 0) {
       throw new FSError('ENOTEMPTY', pathname);
     }
+    this.access(path.dirname(pathname), parseInt('0002', 8));
     var parent = this._system.getItem(path.dirname(pathname));
     parent.removeItem(path.basename(pathname));
   });

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -7,6 +7,8 @@ var mock = require('../../lib/index');
 var os = require('os');
 var path = require('path');
 
+var testParentPerms = (fs.access && fs.accessSync && process.getuid && process.getgid);
+
 describe('The API', function() {
 
   describe('mock()', function() {
@@ -2026,12 +2028,14 @@ describe('Mocking the file system', function() {
       });
     });
 
-    it('fails if parent is not writeable', function(done) {
-      fs.mkdir('unwriteable/child', function(err) {
-        assert.instanceOf(err, Error);
-        done();
+    if (testParentPerms) {
+      it('fails if parent is not writeable', function(done) {
+        fs.mkdir('unwriteable/child', function(err) {
+          assert.instanceOf(err, Error);
+          done();
+        });
       });
-    });
+    }
 
     it('calls callback with a single argument on success', function(done) {
       fs.mkdir('parent/arity', function(_) {
@@ -2090,11 +2094,13 @@ describe('Mocking the file system', function() {
       });
     });
 
-    it('fails if parent is not writeable', function() {
-      assert.throws(function() {
-        fs.mkdirSync('unwriteable/child');
+    if (testParentPerms) {
+      it('fails if parent is not writeable', function() {
+        assert.throws(function() {
+          fs.mkdirSync('unwriteable/child');
+        });
       });
-    });
+    }
   });
 
   describe('fs.rmdir(path, callback)', function() {
@@ -2127,12 +2133,14 @@ describe('Mocking the file system', function() {
       });
     });
 
-    it('fails if parent is not writeable', function(done) {
-      fs.rmdir('unwriteable/child', function(err) {
-        assert.instanceOf(err, Error);
-        done();
+    if (testParentPerms) {
+      it('fails if parent is not writeable', function(done) {
+        fs.rmdir('unwriteable/child', function(err) {
+          assert.instanceOf(err, Error);
+          done();
+        });
       });
-    });
+    }
   });
 
   describe('fs.rmdirSync(path)', function() {
@@ -2169,11 +2177,13 @@ describe('Mocking the file system', function() {
       });
     });
 
-    it('fails if parent is not writeable', function() {
-      assert.throws(function() {
-        fs.rmdirSync('unwriteable/child');
+    if (testParentPerms) {
+      it('fails if parent is not writeable', function() {
+        assert.throws(function() {
+          fs.rmdirSync('unwriteable/child');
+        });
       });
-    });
+    }
   });
 
   describe('fs.chown(path, uid, gid, callback)', function() {


### PR DESCRIPTION
There are several cases WRT the permissions of parent directories where `mock-fs` doesn't accurately mirror a real filesystem's behaviour. This PR highlights and fixes a few of them, in `mkdir` and `rmdir` and their synchronous counterparts. I believe this was reported in #86 (but I didn't read that code in great detail).

I think there are more bugs along similar lines with other functions, but these came to my attention immediately because I encountered them in one of my own projects.

The first commit adds five new tests, four of which fail. The second commit fixes these tests.