### PR TITLE
Use the real fs module if in a require() call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,16 @@ for (var name in mockFs) {
   var descriptor = Object.getOwnPropertyDescriptor(realFs, name);
 
   if (!descriptor || descriptor && descriptor.writable) {
-    realFs[name] = mockFs[name];
+    realFs[name] = (function(mockFunction, realFunction) {
+      return function() {
+        var stack = new Error().stack;
+        if (stack.indexOf('at Module.require (module') >= 0) {
+          return realFunction.apply(realFs, arguments);
+        } else {
+          return mockFunction.apply(realFs, arguments);
+        }
+      };
+    }(mockFs[name], realFs[name]));
   }
 }
 var originalProcess = {

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -64,6 +64,15 @@ describe('The API', function() {
       mock.restore();
     });
 
+    it('uses the real fs module in require() calls', function() {
+      mock({foo: 'bar'});
+
+      var pkg = require('../../package.json');
+      assert.equal(pkg.name, 'mock-fs');
+
+      mock.restore();
+    });
+
   });
 
   describe('mock.restore()', function() {


### PR DESCRIPTION
This makes it so `require()` calls work as expected (with the real `fs`) even after a mock is created.

Fixes #130.
