### PR TITLE
Reduce the manual fs module patching

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -29,7 +29,9 @@ function maybeCallback(callback, thisArg, func) {
       err = e;
     }
     // Unpack callback from FSReqWrap
-    callback = callback.oncomplete || callback;
+    if (callback.oncomplete) {
+      callback = callback.oncomplete.bind(callback);
+    }
     process.nextTick(function() {
       if (val === undefined) {
         callback(err);
@@ -520,7 +522,9 @@ Binding.prototype.writeString = function(fd, string, position, encoding,
   var buffer = new Buffer(string, encoding);
   var wrapper;
   if (callback) {
-    callback = callback.oncomplete || callback;
+    if (callback.oncomplete) {
+      callback = callback.oncomplete.bind(callback);
+    }
     wrapper = function(err, written, returned) {
       callback(err, written, returned && string);
     };

--- a/node/fs-6.3.0.js
+++ b/node/fs-6.3.0.js
@@ -6,7 +6,7 @@
 const util = require('util');
 const pathModule = require('path');
 
-const binding = process.binding('fs');
+let binding = process.binding('fs');
 const constants = require('constants');
 const fs = exports;
 const Buffer = require('buffer').Buffer;
@@ -34,42 +34,6 @@ const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
-
-var printDeprecation;
-try {
-  printDeprecation = require('internal/util').printDeprecationMessage;
-} catch (e) {
-  if (e.code !== 'MODULE_NOT_FOUND') throw e;
-
-  // TODO(ChALkeR): remove this in master after 6.x
-  // This code was based upon internal/util and is required to give users
-  // a grace period before actually breaking modules that re-evaluate fs
-  // sources from context where internal modules are not allowed, e.g.
-  // older versions of graceful-fs module.
-
-  const prefix = `(${process.release.name}:${process.pid}) `;
-
-  printDeprecation = function(msg, warned) {
-    if (process.noDeprecation)
-      return true;
-
-    if (warned)
-      return warned;
-
-    if (process.throwDeprecation)
-      throw new Error(`${prefix}${msg}`);
-    else if (process.traceDeprecation)
-      console.trace(msg);
-    else
-      console.error(`${prefix}${msg}`);
-
-    return true;
-  };
-  printDeprecation('fs: re-evaluating native module sources is not ' +
-                   'supported. If you are using the graceful-fs module, ' +
-                   'please update it to a more recent version.',
-                    false);
-}
 
 function throwOptionsError(options) {
   throw new TypeError('Expected options to be either an object or a string, ' +

--- a/node/fs-6.3.0.js
+++ b/node/fs-6.3.0.js
@@ -6,7 +6,7 @@
 const util = require('util');
 const pathModule = require('path');
 
-let binding = process.binding('fs');
+const binding = process.binding('fs');
 const constants = require('constants');
 const fs = exports;
 const Buffer = require('buffer').Buffer;
@@ -34,6 +34,42 @@ const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
+
+var printDeprecation;
+try {
+  printDeprecation = require('internal/util').printDeprecationMessage;
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') throw e;
+
+  // TODO(ChALkeR): remove this in master after 6.x
+  // This code was based upon internal/util and is required to give users
+  // a grace period before actually breaking modules that re-evaluate fs
+  // sources from context where internal modules are not allowed, e.g.
+  // older versions of graceful-fs module.
+
+  const prefix = `(${process.release.name}:${process.pid}) `;
+
+  printDeprecation = function(msg, warned) {
+    if (process.noDeprecation)
+      return true;
+
+    if (warned)
+      return warned;
+
+    if (process.throwDeprecation)
+      throw new Error(`${prefix}${msg}`);
+    else if (process.traceDeprecation)
+      console.trace(msg);
+    else
+      console.error(`${prefix}${msg}`);
+
+    return true;
+  };
+  printDeprecation('fs: re-evaluating native module sources is not ' +
+                   'supported. If you are using the graceful-fs module, ' +
+                   'please update it to a more recent version.',
+                    false);
+}
 
 function throwOptionsError(options) {
   throw new TypeError('Expected options to be either an object or a string, ' +
@@ -249,7 +285,7 @@ fs.readFile = function(path, options, callback_) {
   context.isUserFd = isFd(path); // file descriptor ownership
   var req = new FSReqWrap();
   req.context = context;
-  req.oncomplete = readFileAfterOpen.bind(req);
+  req.oncomplete = readFileAfterOpen;
 
   if (context.isUserFd) {
     process.nextTick(function() {
@@ -294,7 +330,7 @@ ReadFileContext.prototype.read = function() {
   }
 
   var req = new FSReqWrap();
-  req.oncomplete = readFileAfterRead.bind(req);
+  req.oncomplete = readFileAfterRead;
   req.context = this;
 
   binding.read(this.fd, buffer, offset, length, -1, req);
@@ -302,7 +338,7 @@ ReadFileContext.prototype.read = function() {
 
 ReadFileContext.prototype.close = function(err) {
   var req = new FSReqWrap();
-  req.oncomplete = readFileAfterClose.bind(req);
+  req.oncomplete = readFileAfterClose;
   req.context = this;
   this.err = err;
 
@@ -327,7 +363,7 @@ function readFileAfterOpen(err, fd) {
   context.fd = fd;
 
   var req = new FSReqWrap();
-  req.oncomplete = readFileAfterStat.bind(req);
+  req.oncomplete = readFileAfterStat;
   req.context = context;
   binding.fstat(fd, req);
 }


### PR DESCRIPTION
This reduces the amount of manual patching done to the `fs` module.  The only significant part left is changing `const binding = process.binding('fs')` to `let binding = process.binding('fs')`.  It will be good to come up with an alternative there as well.