### PR TITLE
Add note about restoring the fs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ mock({
 });
 ```
 
-When you are ready to restore the `fs` module (so that it is backed by your real file system), call [`mock.restore()`](#mockrestore). Note that calling this maybe **mandatory** in some cases. See [istanbuljs/nyc#324](https://github.com/istanbuljs/nyc/issues/324#issuecomment-234018654)
+When you are ready to restore the `fs` module (so that it is backed by your real file system), call [`mock.restore()`](#mockrestore). Note that calling this may be **mandatory** in some cases. See [istanbuljs/nyc#324](https://github.com/istanbuljs/nyc/issues/324#issuecomment-234018654)
 
 ```js
 // after a test runs

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ mock({
 });
 ```
 
-When you are ready to restore the `fs` module (so that it is backed by your real file system), call [`mock.restore()`](#mockrestore).
+When you are ready to restore the `fs` module (so that it is backed by your real file system), call [`mock.restore()`](#mockrestore). Note that calling this maybe **mandatory** in some cases. See [istanbuljs/nyc#324](https://github.com/istanbuljs/nyc/issues/324#issuecomment-234018654)
 
 ```js
 // after a test runs


### PR DESCRIPTION
In some cases, not restoring the `fs` can produce side effects. If you are using [`nyc`](https://github.com/istanbuljs/nyc), for example, the reporting never ends. See istanbuljs/nyc#324