### PR TITLE
Fix native re-requires

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,9 @@
  * again after this one.
  */
 Object.keys(require.cache).forEach(function(key) {
-  if (key.indexOf(__dirname) === -1) {
+  var nativeSuffix = '.node';
+  var isNative = key.indexOf(nativeSuffix, key.length - nativeSuffix.length) !== -1;
+  if (key.indexOf(__dirname) === -1 && !isNative) {
     delete require.cache[key];
   }
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "scripts": {
     "pretest": "eslint benchmarks lib test",
-    "test": "mocha --recursive test",
+    "test": "mocha --recursive -r native-module/hello test",
     "bench": "bench benchmarks"
   },
   "devDependencies": {
@@ -35,6 +35,7 @@
     "eslint": "2.13.0",
     "eslint-config-tschaub": "6.0.0",
     "fs-extra": "^0.30.0",
+    "native-module": "^0.11.3",
     "mocha": "3.1.2",
     "rimraf": "2.5.4"
   },

--- a/test/integration/native-module-require.spec.js
+++ b/test/integration/native-module-require.spec.js
@@ -1,0 +1,10 @@
+/**
+ * native-module MUST have been pre-required by mocha in order for this test to
+ * fail properly.
+ */
+describe('native module re-requires', function() {
+  it('should work', function() {
+    require('../../lib/index');
+    require('native-module/hello');
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/tschaub/mock-fs/issues/178. As that issue mentions, native modules cannot be re-required after being deleted from the cache (see https://github.com/nodejs/node/issues/6160).

I've kept the commits separate for now to show the failing test. I'd be happy to squash before (possible) merge.

Honestly, both my test and solution feel a little bit like hacks, but I'm not sure there's another way. Perhaps that's the nature of testing/messing with the require cache? Feedback is very welcome.