### PR TITLE
Exposes the root mocked filesytem if the mock is currently applied. (Fixes #90)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@ var realProcessProps = {
   chdir: process.chdir
 };
 
-
 function overrideBinding(binding) {
   for (var key in binding) {
     if (typeof binding[key] === 'function') {
@@ -30,8 +29,15 @@ function overrideProcess(cwd, chdir) {
 }
 
 function restoreBinding() {
-  for (var key in realBindingProps) {
+  var key;
+  for (key in realBindingProps) {
     realBinding[key] = realBindingProps[key];
+  }
+  // Delete excess keys that came in when the binding was originally applied.
+  for (key in realBinding) {
+    if (typeof realBindingProps[key] === 'undefined') {
+      delete realBinding[key];
+    }
   }
 }
 
@@ -53,6 +59,7 @@ function restoreProcess() {
 var exports = module.exports = function mock(config, options) {
   var system = FileSystem.create(config, options);
   var binding = new Binding(system);
+
   overrideBinding(binding);
 
   var currentPath = process.cwd();
@@ -69,6 +76,17 @@ var exports = module.exports = function mock(config, options) {
   );
 };
 
+/**
+ * Get hold of the mocked filesystem's 'root'
+ * If fs hasn't currently been replaced, this will return an empty object
+ */
+exports.getMockRoot = function() {
+  if (typeof realBinding.getSystem === 'undefined') {
+    return {};
+  } else {
+    return realBinding.getSystem().getRoot();
+  }
+};
 
 /**
  * Restore the fs bindings for the real file system.

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -23,6 +23,14 @@ describe('The API', function() {
       mock.restore();
     });
 
+    it('provides direct access to the internal filesystem object', function() {
+      mock();
+      var root = mock.getMockRoot();
+      assert.notDeepEqual(root, {});
+      mock.restore();
+      assert.deepEqual(mock.getMockRoot(), {});
+    });
+
     it('creates process.cwd() and os.tmpdir() by default', function() {
       mock();
 


### PR DESCRIPTION
Addresses  #90 
* Useful for tests where you wish to make 'general' assertions over the
  whole filesystem (e.g. security testing!)
* Also addresses an issue where the bindings were having 'extraneous' keys
  left when the mock was restored. (Was unable to provide an isolated test
  for this as the 'bindings' part is internal to the mock.
