### PR TITLE
Binding.open not following symlinks correctly

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -327,7 +327,7 @@ Binding.prototype.open = function(pathname, flags, mode, callback) {
   return maybeCallback(callback, this, function() {
     var descriptor = new FileDescriptor(flags);
     var item = this._system.getItem(pathname);
-    if (item instanceof SymbolicLink) {
+    while (item instanceof SymbolicLink) {
       item = this._system.getItem(
           path.resolve(path.dirname(pathname), item.getPath()));
     }

--- a/test/lib/binding.spec.js
+++ b/test/lib/binding.spec.js
@@ -763,7 +763,6 @@ describe('Binding', function() {
             parseInt('0666', 8));
       });
     });
-
   });
 
   describe('#close()', function() {
@@ -818,6 +817,15 @@ describe('Binding', function() {
     it('reads from a symbolic link', function() {
       var binding = new Binding(system);
       var fd = binding.open(path.join('mock-dir', 'one-link.txt'), flags('r'));
+      var buffer = new Buffer(11);
+      var read = binding.read(fd, buffer, 0, 11, 0);
+      assert.equal(read, 11);
+      assert.equal(String(buffer), 'one content');
+    });
+
+    it('reads from a deeply linked symlink', function() {
+      var binding = new Binding(system);
+      var fd = binding.open(path.join('mock-dir', 'one-link2.txt'), flags('r'));
       var buffer = new Buffer(11);
       var read = binding.read(fd, buffer, 0, 11, 0);
       assert.equal(read, 11);

--- a/test/lib/binding.spec.js
+++ b/test/lib/binding.spec.js
@@ -763,6 +763,7 @@ describe('Binding', function() {
             parseInt('0666', 8));
       });
     });
+
   });
 
   describe('#close()', function() {


### PR DESCRIPTION
Binding.open only follows a symlink once, so I fixed it so that it follows the symlink chain until the end.