### PR TITLE
Throw error if item content is invalid

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -138,12 +138,14 @@ function populate(directory, name, obj) {
   } else if (typeof obj === 'function') {
     // item factory
     item = obj();
-  } else {
+  } else if (typeof obj === 'object') {
     // directory with more to populate
     item = new Directory();
     for (var key in obj) {
       populate(item, key, obj[key]);
     }
+  } else {
+    throw new Error('Unsupported type: ' + typeof obj + ' of item ' + name);
   }
   /**
    * Special exception for redundant adding of empty directories.

--- a/test/lib/filesystem.spec.js
+++ b/test/lib/filesystem.spec.js
@@ -311,4 +311,26 @@ describe('FileSystem.create', function() {
      */
     assert.equal(system.getItem('/dir-a.0/dir-b.0/symlink-c.0').links, 1);
   });
+
+  it('throws if item content is not valid type', function() {
+    assert.throws(function() {
+      FileSystem.create({
+        '/dir-a.0': {
+          'dir-b.0': {
+            'file-c.0': undefined
+          }
+        }
+      });
+    });
+
+    assert.throws(function() {
+      FileSystem.create({
+        '/dir-a.0': {
+          'dir-b.0': {
+            'file-c.0': 123
+          }
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
I've wasted some time trying to understand root cause of random EBADF's in my tests.
Like this:
```
Error: EBADF, bad file descriptor
    at Binding.<anonymous> (/Users/cornholio/dev/veendor/node_modules/mock-fs/lib/binding.js:463:13)
    at maybeCallback (/Users/cornholio/dev/veendor/node_modules/mock-fs/lib/binding.js:30:18)
    at Binding.read (/Users/cornholio/dev/veendor/node_modules/mock-fs/lib/binding.js:455:10)
    at ReadFileContext.read (fs.js:342:11)
    at FSReqWrap.readFileAfterStat [as oncomplete] (fs.js:387:13)
    at /Users/cornholio/dev/veendor/node_modules/mock-fs/lib/binding.js:75:16
    at /Users/cornholio/dev/veendor/node_modules/mock-fs/lib/binding.js:38:9
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```
And was surprised finding that I was reading file, which contents were set to undefined in config.

After this PR, I get error on calling `mockfs`:
```
Error: Unsupported type: undefined of item package.json
    at populate (node_modules/mock-fs/lib/filesystem.js:148:15)
    at Function.FileSystem.create (node_modules/mock-fs/lib/filesystem.js:192:9)
    at mock (node_modules/mock-fs/lib/index.js:59:27)
    at Context.beforeEach (test/unit/install.test.js:41:9)
```