### PR TITLE
Throw ENOENT in readlink when item is missing

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -1035,6 +1035,9 @@ Binding.prototype.readlink = function(pathname, encoding, callback) {
   }
   return maybeCallback(normalizeCallback(callback), this, function() {
     var link = this._system.getItem(pathname);
+    if (!link) {
+      throw new FSError('ENOENT', pathname);
+    }
     if (!(link instanceof SymbolicLink)) {
       throw new FSError('EINVAL', pathname);
     }

--- a/test/lib/binding.spec.js
+++ b/test/lib/binding.spec.js
@@ -1506,21 +1506,21 @@ describe('Binding', function() {
       var binding = new Binding(system);
       assert.throws(function() {
         binding.readlink(path.join('mock-dir', 'one.txt'));
-      });
+      }, /EINVAL/);
     });
 
     it('fails for directories', function() {
       var binding = new Binding(system);
       assert.throws(function() {
         binding.readlink(path.join('mock-dir', 'empty'));
-      });
+      }, /EINVAL/);
     });
 
     it('fails for bogus paths', function() {
       var binding = new Binding(system);
       assert.throws(function() {
         binding.readlink(path.join('mock-dir', 'bogus'));
-      });
+      }, /ENOENT/);
     });
   });
 


### PR DESCRIPTION
Add error code check to readlink failure assertions.

Fixes #231