### PR TITLE
Fix stat calls to work with changes in Node 10

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -325,11 +325,15 @@ function fillStatsArray(stats, statValues) {
 /**
  * Stat an item.
  * @param {string} filepath Path.
- * @param {function(Error, Stats)|Float64Array} callback Callback (optional). In Node 7.7.0+ this will be a Float64Array
+ * @param {function(Error, Stats)|Float64Array|BigUint64Array} callback Callback (optional). In Node 7.7.0+ this will be a Float64Array
  * that should be filled with stat values.
  * @return {Stats|undefined} Stats or undefined (if sync).
  */
-Binding.prototype.stat = function(filepath, callback) {
+Binding.prototype.stat = function(filepath, options, callback) {
+  if (arguments.length < 3) {
+    callback = options;
+    options = {};
+  }
   return maybeCallback(wrapStatsCallback(callback), this, function() {
     var item = this._system.getItem(filepath);
     if (item instanceof SymbolicLink) {
@@ -345,7 +349,8 @@ Binding.prototype.stat = function(filepath, callback) {
     // In Node 7.7.0+, binding.stat accepts a Float64Array as the second argument,
     // which should be filled with stat values.
     // In prior versions of Node, binding.stat simply returns a Stats instance.
-    if (callback instanceof Float64Array) {
+    if (callback instanceof Float64Array ||
+        callback instanceof BigUint64Array) {
       fillStatsArray(stats, callback);
     } else {
       fillStatsArray(stats, statValues);
@@ -357,11 +362,15 @@ Binding.prototype.stat = function(filepath, callback) {
 /**
  * Stat an item.
  * @param {number} fd File descriptor.
- * @param {function(Error, Stats)|Float64Array} callback Callback (optional). In Node 7.7.0+ this will be a Float64Array
+ * @param {function(Error, Stats)|Float64Array|BigUint64Array} callback Callback (optional). In Node 7.7.0+ this will be a Float64Array
  * that should be filled with stat values.
  * @return {Stats|undefined} Stats or undefined (if sync).
  */
-Binding.prototype.fstat = function(fd, callback) {
+Binding.prototype.fstat = function(fd, options, callback) {
+  if (arguments.length < 3) {
+    callback = options;
+    options = {};
+  }
   return maybeCallback(wrapStatsCallback(callback), this, function() {
     var descriptor = this._getDescriptorById(fd);
     var item = descriptor.getItem();
@@ -370,7 +379,8 @@ Binding.prototype.fstat = function(fd, callback) {
     // In Node 7.7.0+, binding.stat accepts a Float64Array as the second argument,
     // which should be filled with stat values.
     // In prior versions of Node, binding.stat simply returns a Stats instance.
-    if (callback instanceof Float64Array) {
+    if (callback instanceof Float64Array ||
+        callback instanceof BigUint64Array) {
       fillStatsArray(stats, callback);
     } else {
       fillStatsArray(stats, statValues);
@@ -1066,11 +1076,15 @@ Binding.prototype.readlink = function(pathname, encoding, callback) {
 /**
  * Stat an item.
  * @param {string} filepath Path.
- * @param {function(Error, Stats)|Float64Array} callback Callback (optional). In Node 7.7.0+ this will be a Float64Array
+ * @param {function(Error, Stats)|Float64Array|BigUint64Array} callback Callback (optional). In Node 7.7.0+ this will be a Float64Array
  * that should be filled with stat values.
  * @return {Stats|undefined} Stats or undefined (if sync).
  */
-Binding.prototype.lstat = function(filepath, callback) {
+Binding.prototype.lstat = function(filepath, options, callback) {
+  if (arguments.length < 3) {
+    callback = options;
+    options = {};
+  }
   return maybeCallback(wrapStatsCallback(callback), this, function() {
     var item = this._system.getItem(filepath);
     if (!item) {
@@ -1081,7 +1095,8 @@ Binding.prototype.lstat = function(filepath, callback) {
     // In Node 7.7.0+, binding.stat accepts a Float64Array as the second argument,
     // which should be filled with stat values.
     // In prior versions of Node, binding.stat simply returns a Stats instance.
-    if (callback instanceof Float64Array) {
+    if (callback instanceof Float64Array ||
+        callback instanceof BigUint64Array) {
       fillStatsArray(stats, callback);
     } else {
       fillStatsArray(stats, statValues);


### PR DESCRIPTION
This is a partial fix for #238 which addresses the failures relating to the stat calls, but not those relating to streams.