### PR TITLE
Throw error when a directory is opened

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -457,6 +457,12 @@ Binding.prototype.open = function(pathname, flags, mode, callback) {
     if (descriptor.isWrite() && !item.canWrite()) {
       throw new FSError('EACCES', pathname);
     }
+    if (
+      item instanceof Directory &&
+      (descriptor.isTruncate() || descriptor.isAppend())
+    ) {
+      throw new FSError('EISDIR', pathname);
+    }
     if (descriptor.isTruncate()) {
       item.setContent('');
     }

--- a/test/lib/binding.spec.js
+++ b/test/lib/binding.spec.js
@@ -695,6 +695,13 @@ describe('Binding', function() {
       assert.equal(String(file.getContent()), '');
     });
 
+    it('generates error if file is directory (w)', function() {
+      var binding = new Binding(system);
+      assert.throws(function() {
+        binding.open('mock-dir', flags('w'));
+      });
+    });
+
     it('generates error if file exists (wx)', function() {
       var binding = new Binding(system);
       assert.throws(function() {
@@ -762,6 +769,13 @@ describe('Binding', function() {
       var file = system.getItem(path.join('mock-dir', 'one.txt'));
       assert.instanceOf(file, File);
       assert.equal(String(file.getContent()), 'one content');
+    });
+
+    it('generates error if file is directory (a)', function() {
+      var binding = new Binding(system);
+      assert.throws(function() {
+        binding.open('mock-dir', flags('a'));
+      });
     });
 
     it('opens a new file for appending (ax)', function() {


### PR DESCRIPTION
We should throw an error when someone attempts to open a mocked directory. When we try to write to a directory currently, we don't do this properly and it causes a confusing error to be thrown.

*Node Version: v8.11.3*

```
const mockFS = require('mock-fs');
const fs = require('fs');

mockFS({
   '/my/dir': {FOO: ''}
});

fs.writeFileSync('/my/dir', 'bar');
```
Results in 
```
TypeError: item.setContent is not a function
    at Binding.<anonymous> (.../node_modules/mock-fs/lib/binding.js:442:12)
    at maybeCallback (.../node_modules/mock-fs/lib/binding.js:53:17)
    at Binding.open (.../node_modules/mock-fs/lib/binding.js:402:10)
    ...
```
Because we try to zero out the file content [here](https://github.com/tschaub/mock-fs/blob/master/lib/binding.js#L460-L465), but there is no content to modify on a directory.

With this patch the same code results in 
```
Error: EISDIR, illegal operation on a directory '/my/dir'
    at Binding.<anonymous> (.../node_modules/mock-fs/lib/binding.js:464:13)
    at maybeCallback (.../node_modules/mock-fs/lib/binding.js:61:17)
    at Binding.open (.../node_modules/mock-fs/lib/binding.js:424:10)
```