### PR TITLE
rbinding.readdir can take anywhere from 2 to 4 arguments

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -692,14 +692,25 @@ Binding.prototype.rename = function(oldPath, newPath, callback) {
  * Read a directory.
  * @param {string} dirpath Path to directory.
  * @param {string} encoding The encoding ('utf-8' or 'buffer').
+ * @param {boolean} withFileTypes whether or not to return fs.Dirent objects
  * @param {function(Error, (Array.<string>|Array.<Buffer>)} callback Callback
  *     (optional) called with any error or array of items in the directory.
  * @return {Array.<string>|Array.<Buffer>} Array of items in directory (if sync).
  */
-Binding.prototype.readdir = function(dirpath, encoding, callback) {
-  if (encoding && typeof encoding !== 'string') {
+Binding.prototype.readdir = function(
+  dirpath,
+  encoding,
+  withFileTypes,
+  callback
+) {
+  if (arguments.length === 2) {
     callback = encoding;
     encoding = 'utf-8';
+  } else if (arguments.length === 3) {
+    callback = withFileTypes;
+  }
+  if (withFileTypes === true) {
+    notImplemented();
   }
   return maybeCallback(normalizeCallback(callback), this, function() {
     var dpath = dirpath;


### PR DESCRIPTION
fixes #250 

Does not provide support for DirEnt objects that were introduced in `10.10.0` with https://github.com/nodejs/node/commit/c7944a7a7bd92a446ea81d774ccad31e0e7c8a3f
But makes `fs.readdir` and `fs.readdirSync` work again.