### PR TITLE
test: turn on tests on nodejs v4, but skip it on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,16 @@ os:
   - linux
   - windows
   - osx
-
 language: node_js
 node_js:
+  - "4"
   - "6"
   - "8"
   - "10"
   - "12"
+matrix:
+  exclude:
+    - os: windows
+      node_js: "4"
+before_install:
+  - if [[ $TRAVIS_OS_NAME != 'windows' ]] && [[ `npm -v` == 2.* ]]; then nvm install-latest-npm; fi


### PR DESCRIPTION
It excludes nodejs v4 from windows tests instead of allowing it to fail.
Thank @ljharb to show me how to do the condition.