### PR TITLE
fix: fix wrong promise rejection on some fs methods with no return value

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -60,7 +60,7 @@ function maybeCallback(callback, ctx, thisArg, func) {
     }
     return new Promise(function(resolve, reject) {
       process.nextTick(function() {
-        if (val === undefined) {
+        if (err) {
           reject(err);
         } else {
           resolve(val);


### PR DESCRIPTION
fs.promises.readFile triggers a list of different calls, the last one is "close". The "close" call has no return value, so we cannot check the existence of "val" to determine successfulness.

closes #278