### PR TITLE
fix: throw ENOTDIR when trying to open an incorrect path (nested under existing file)

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -110,6 +110,9 @@ FileSystem.prototype.getItem = function(filepath) {
           throw new FSError('EACCES', filepath);
         }
       }
+      if (item instanceof File) {
+        throw new FSError('ENOTDIR', filepath);
+      }
       item = item.getItem(name);
     }
     if (!item) {

--- a/test/lib/binding.spec.js
+++ b/test/lib/binding.spec.js
@@ -918,6 +918,16 @@ describe('Binding', function() {
         binding.read(fd, buffer, 0, 11, 0);
       });
     });
+
+    it('throws ENOTDIR when trying to open an incorrect path (nested under existing file)', function() {
+      const binding = new Binding(system);
+      assert.throws(function() {
+        binding.open(
+          path.join('mock-dir', 'two.txt', 'bogus-path'),
+          flags('r')
+        );
+      }, 'ENOTDIR');
+    });
   });
 
   describe('#write()', function() {


### PR DESCRIPTION
If you have a file: `/mock-dir/two.txt` and try to open `/mock-dir/two.txt/bogus-path`, you would get `item.getItem is not a function` Error due to `item` instance being a File, not a Directory.

This adds a fix to this by checking the instance of resolved `item` and throwing accordingly. 

This matches node's native behavior in such a case.