### PR TITLE
Implementing "withFileTypes" option for fs.readdir method

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -12,6 +12,16 @@ const getPathParts = require('./filesystem').getPathParts;
 const bufferFrom = require('./buffer').from;
 const bufferAlloc = require('./buffer').alloc;
 
+const MODE_TO_KTYPE = {
+  [constants.S_IFREG]: constants.UV_DIRENT_FILE,
+  [constants.S_IFDIR]: constants.UV_DIRENT_DIR,
+  [constants.S_IFBLK]: constants.UV_DIRENT_BLOCK,
+  [constants.S_IFCHR]: constants.UV_DIRENT_CHAR,
+  [constants.S_IFLNK]: constants.UV_DIRENT_LINK,
+  [constants.S_IFIFO]: constants.UV_DIRENT_FIFO,
+  [constants.S_IFSOCK]: constants.UV_DIRENT_SOCKET
+};
+
 /** Workaround for optimizations in node 8+ */
 const fsBinding = process.binding('fs');
 const kUsePromises = fsBinding.kUsePromises;
@@ -138,6 +148,16 @@ function wrapStatsCallback(callback) {
   } else {
     return callback;
   }
+}
+
+function getDirentType(mode) {
+  const ktype = MODE_TO_KTYPE[mode & constants.S_IFMT];
+
+  if (ktype === undefined) {
+    return constants.UV_DIRENT_UNKNOWN;
+  }
+
+  return ktype;
 }
 
 function notImplemented() {
@@ -914,9 +934,6 @@ Binding.prototype.readdir = function(
   } else if (arguments.length === 3) {
     callback = withFileTypes;
   }
-  if (withFileTypes === true) {
-    notImplemented();
-  }
 
   markSyscall(ctx, 'scandir');
 
@@ -933,12 +950,23 @@ Binding.prototype.readdir = function(
     if (!(dir instanceof Directory)) {
       throw new FSError('ENOTDIR', dirpath);
     }
+
     let list = dir.list();
     if (encoding === 'buffer') {
       list = list.map(function(item) {
         return bufferFrom(item);
       });
     }
+
+    if (withFileTypes === true) {
+      const types = list.map(function(name) {
+        const stats = dir.getItem(name).getStats();
+
+        return getDirentType(stats.mode);
+      });
+      list = [list, types];
+    }
+
     return list;
   });
 };

--- a/test/lib/fs.readdir.spec.js
+++ b/test/lib/fs.readdir.spec.js
@@ -7,6 +7,7 @@ const path = require('path');
 
 const assert = helper.assert;
 const withPromise = helper.withPromise;
+const inVersion = helper.inVersion;
 
 describe('fs.readdir(path, callback)', function() {
   beforeEach(function() {
@@ -81,6 +82,95 @@ describe('fs.readdir(path, callback)', function() {
       }
     );
   });
+
+  inVersion('>=10.10').it('should support "withFileTypes" option', function(
+    done
+  ) {
+    fs.readdir(
+      path.join('nested', 'sub', 'dir'),
+      {withFileTypes: true},
+      function(err, items) {
+        assert.isNull(err);
+        assert.isArray(items);
+        assert.deepEqual(items, [
+          {name: 'empty'},
+          {name: 'one.txt'},
+          {name: 'two.txt'}
+        ]);
+        assert.ok(items[0].isDirectory());
+        assert.ok(items[1].isFile());
+        assert.ok(items[2].isFile());
+        done();
+      }
+    );
+  });
+
+  withPromise.it('should support "withFileTypes" option', function(done) {
+    fs.promises
+      .readdir(path.join('nested', 'sub', 'dir'), {withFileTypes: true})
+      .then(function(items) {
+        assert.isArray(items);
+        assert.deepEqual(items, [
+          {name: 'empty'},
+          {name: 'one.txt'},
+          {name: 'two.txt'}
+        ]);
+        assert.ok(items[0].isDirectory());
+        assert.ok(items[1].isFile());
+        assert.ok(items[2].isFile());
+        done();
+      }, done);
+  });
+
+  inVersion('>=10.10').it(
+    'should support "withFileTypes" option with "encoding" option',
+    function(done) {
+      fs.readdir(
+        path.join('nested', 'sub', 'dir'),
+        {withFileTypes: true, encoding: 'buffer'},
+        function(err, items) {
+          assert.isNull(err);
+          assert.isArray(items);
+          items.forEach(function(item) {
+            assert.equal(Buffer.isBuffer(item.name), true);
+          });
+          const names = items.map(function(item) {
+            return item.name.toString();
+          });
+          assert.deepEqual(names, ['empty', 'one.txt', 'two.txt']);
+          assert.ok(items[0].isDirectory());
+          assert.ok(items[1].isFile());
+          assert.ok(items[2].isFile());
+          done();
+        }
+      );
+    }
+  );
+
+  withPromise.it(
+    'should support "withFileTypes" option with "encoding" option',
+    function(done) {
+      fs.promises
+        .readdir(path.join('nested', 'sub', 'dir'), {
+          withFileTypes: true,
+          encoding: 'buffer'
+        })
+        .then(function(items) {
+          assert.isArray(items);
+          items.forEach(function(item) {
+            assert.equal(Buffer.isBuffer(item.name), true);
+          });
+          const names = items.map(function(item) {
+            return item.name.toString();
+          });
+          assert.deepEqual(names, ['empty', 'one.txt', 'two.txt']);
+          assert.ok(items[0].isDirectory());
+          assert.ok(items[1].isFile());
+          assert.ok(items[2].isFile());
+          done();
+        });
+    }
+  );
 });
 
 describe('fs.readdirSync(path)', function() {


### PR DESCRIPTION
Hi, I'm the maintainer of the [`fast-glob`](https://github.com/mrmlnc/fast-glob) package.

In my package, I try to use all possible ways to optimize the work with the file system. One of these ways is a `withFileTypes` option in the `fs.readdir` method. Unfortunately, this package does not support this option. So, this pull request implements support for this option.

This is a possible solution for the following issues:

* https://github.com/tschaub/mock-fs/issues/272
* https://github.com/mrmlnc/fast-glob/issues/246

My solution uses an internal implementation of the [`getDirents`](https://github.com/bengl/node/blob/f01ed4307e0dfa5f8a1189d9fd3fb93078814dda/lib/internal/fs/utils.js#L121) method from [`FSReqWrap`](https://github.com/bengl/node/blob/f01ed4307e0dfa5f8a1189d9fd3fb93078814dda/lib/fs.js#L777-L788), because I don't know how to replace callback. I will accept any suggestions if it really needs to be done.

I checked that my changes are working by the following script:

```js
const mock = require('.');
const fg = require('fast-glob');

mock({
    first: 'content',
    second: {},
    third: {
        nested: {
            file: 'content'
        }
    }
});

const entries = fg.sync('**/*', { onlyFiles: false, objectMode: true });

console.dir(entries, { colors: true });

[ { dirent: Dirent { name: 'first', [Symbol(type)]: 1 },
    name: 'first',
    path: 'first' },
  { dirent: Dirent { name: 'second', [Symbol(type)]: 2 },
    name: 'second',
    path: 'second' },
  { dirent: Dirent { name: 'third', [Symbol(type)]: 2 },
    name: 'third',
    path: 'third' },
  { dirent: Dirent { name: 'nested', [Symbol(type)]: 2 },
    name: 'nested',
    path: 'third/nested' },
  { dirent: Dirent { name: 'file', [Symbol(type)]: 1 },
    name: 'file',
    path: 'third/nested/file' } ]
```