### PR TITLE
fix: fix isRead check on file descriptor

### DIFF
--- a/lib/descriptor.js
+++ b/lib/descriptor.js
@@ -80,12 +80,7 @@ FileDescriptor.prototype.isCreate = function() {
  * @return {boolean} Opened for reading.
  */
 FileDescriptor.prototype.isRead = function() {
-  // special treatment because O_RDONLY is 0
-  return (
-    this._flags === constants.O_RDONLY ||
-    this._flags === (constants.O_RDONLY | constants.O_SYNC) ||
-    (this._flags & constants.O_RDWR) === constants.O_RDWR
-  );
+  return (this._flags & constants.O_WRONLY) !== constants.O_WRONLY;
 };
 
 /**

--- a/test/lib/descriptor.spec.js
+++ b/test/lib/descriptor.spec.js
@@ -91,8 +91,8 @@ describe('FileDescriptor', function() {
       assert.isTrue(fd.isAppend());
     });
 
-    it('not opened for appending (O_CREAT)', function() {
-      const fd = new FileDescriptor(constants.O_CREAT);
+    it('not opened for appending (O_CREAT | O_RDONLY)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT | constants.O_RDONLY);
       assert.isFalse(fd.isAppend());
     });
   });
@@ -158,8 +158,8 @@ describe('FileDescriptor', function() {
       assert.isFalse(fd.isTruncate());
     });
 
-    it('not opened for truncating (O_CREAT)', function() {
-      const fd = new FileDescriptor(constants.O_CREAT);
+    it('not opened for truncating (O_CREAT | O_RDONLY)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT | constants.O_RDONLY);
       assert.isFalse(fd.isTruncate());
     });
   });
@@ -225,8 +225,8 @@ describe('FileDescriptor', function() {
       assert.isTrue(fd.isCreate());
     });
 
-    it('opened for creation (O_CREAT)', function() {
-      const fd = new FileDescriptor(constants.O_CREAT);
+    it('opened for creation (O_CREAT | O_RDONLY)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT | constants.O_RDONLY);
       assert.isTrue(fd.isCreate());
     });
   });
@@ -292,8 +292,8 @@ describe('FileDescriptor', function() {
       assert.isTrue(fd.isRead());
     });
 
-    it('opened for reading (O_CREAT)', function() {
-      const fd = new FileDescriptor(constants.O_CREAT);
+    it('opened for reading (O_CREAT | O_RDONLY)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT | constants.O_RDONLY);
       assert.isTrue(fd.isRead());
     });
   });
@@ -359,8 +359,8 @@ describe('FileDescriptor', function() {
       assert.isTrue(fd.isWrite());
     });
 
-    it('not opened for writing (O_CREAT)', function() {
-      const fd = new FileDescriptor(constants.O_CREAT);
+    it('not opened for writing (O_CREAT | O_RDONLY)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT | constants.O_RDONLY);
       assert.isFalse(fd.isWrite());
     });
   });
@@ -426,8 +426,8 @@ describe('FileDescriptor', function() {
       assert.isTrue(fd.isExclusive());
     });
 
-    it('not opened for exclusive (O_CREAT)', function() {
-      const fd = new FileDescriptor(constants.O_CREAT);
+    it('not opened for exclusive (O_CREAT | O_RDONLY)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT | constants.O_RDONLY);
       assert.isFalse(fd.isExclusive());
     });
   });

--- a/test/lib/descriptor.spec.js
+++ b/test/lib/descriptor.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const constants = require('constants');
 const FileDescriptor = require('../../lib/descriptor');
 const helper = require('../helper');
 
@@ -89,6 +90,11 @@ describe('FileDescriptor', function() {
       const fd = new FileDescriptor(flags('ax+'));
       assert.isTrue(fd.isAppend());
     });
+
+    it('not opened for appending (O_CREAT)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT);
+      assert.isFalse(fd.isAppend());
+    });
   });
 
   describe('#isTruncate()', function() {
@@ -149,6 +155,11 @@ describe('FileDescriptor', function() {
 
     it('not opened for truncating (ax+)', function() {
       const fd = new FileDescriptor(flags('ax+'));
+      assert.isFalse(fd.isTruncate());
+    });
+
+    it('not opened for truncating (O_CREAT)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT);
       assert.isFalse(fd.isTruncate());
     });
   });
@@ -213,6 +224,11 @@ describe('FileDescriptor', function() {
       const fd = new FileDescriptor(flags('ax+'));
       assert.isTrue(fd.isCreate());
     });
+
+    it('opened for creation (O_CREAT)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT);
+      assert.isTrue(fd.isCreate());
+    });
   });
 
   describe('#isRead()', function() {
@@ -273,6 +289,11 @@ describe('FileDescriptor', function() {
 
     it('opened for reading (ax+)', function() {
       const fd = new FileDescriptor(flags('ax+'));
+      assert.isTrue(fd.isRead());
+    });
+
+    it('opened for reading (O_CREAT)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT);
       assert.isTrue(fd.isRead());
     });
   });
@@ -337,6 +358,11 @@ describe('FileDescriptor', function() {
       const fd = new FileDescriptor(flags('ax+'));
       assert.isTrue(fd.isWrite());
     });
+
+    it('not opened for writing (O_CREAT)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT);
+      assert.isFalse(fd.isWrite());
+    });
   });
 
   describe('#isExclusive()', function() {
@@ -398,6 +424,11 @@ describe('FileDescriptor', function() {
     it('opened exclusive (ax+)', function() {
       const fd = new FileDescriptor(flags('ax+'));
       assert.isTrue(fd.isExclusive());
+    });
+
+    it('not opened for exclusive (O_CREAT)', function() {
+      const fd = new FileDescriptor(constants.O_CREAT);
+      assert.isFalse(fd.isExclusive());
     });
   });
 });


### PR DESCRIPTION
The argument flags must include one of the following access modes:
O_RDONLY, O_WRONLY, or O_RDWR.  These request opening the file read-
only, write-only, or read/write, respectively.
O_RDONLY is 0, O_WRONLY is 1, O_RDWR is 2, the flags use 2 bits for 3 states: 0 (0b00) / 1 (0b01) / 2 (0b10), the 2 bits will never be 3 (0b11).

closes #288