### PR TITLE
fix: readdir should check for access rights, fixes #294

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -962,8 +962,9 @@ Binding.prototype.readdir = function(
     if (!(dir instanceof Directory)) {
       throw new FSError('ENOTDIR', dirpath);
     }
-
-    this.access(dirpath, parseInt('0002', 8));
+    if (!dir.canRead()) {
+      throw new FSError('EACCES', dirpath);
+    }
 
     let list = dir.list();
     if (encoding === 'buffer') {

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -963,6 +963,8 @@ Binding.prototype.readdir = function(
       throw new FSError('ENOTDIR', dirpath);
     }
 
+    this.access(dirpath, parseInt('0002', 8));
+
     let list = dir.list();
     if (encoding === 'buffer') {
       list = list.map(function(item) {

--- a/test/lib/fs.readdir.spec.js
+++ b/test/lib/fs.readdir.spec.js
@@ -103,6 +103,7 @@ describe('fs.readdir(path, callback)', function() {
   it('calls with an error for restricted path', function(done) {
     fs.readdir('denied', function(err, items) {
       assert.instanceOf(err, Error);
+      assert.equal(err.code, 'EACCES');
       assert.isUndefined(items);
       done();
     });
@@ -118,6 +119,7 @@ describe('fs.readdir(path, callback)', function() {
       },
       function(err) {
         assert.instanceOf(err, Error);
+        assert.equal(err.code, 'EACCES');
         done();
       }
     );

--- a/test/lib/fs.readdir.spec.js
+++ b/test/lib/fs.readdir.spec.js
@@ -21,7 +21,15 @@ describe('fs.readdir(path, callback)', function() {
             empty: {}
           }
         }
-      }
+      },
+      denied: mock.directory({
+        mode: 0o000,
+        items: [
+          {
+            'one.txt': 'content'
+          }
+        ]
+      })
     });
   });
   afterEach(mock.restore);
@@ -81,6 +89,29 @@ describe('fs.readdir(path, callback)', function() {
 
   withPromise.it('promise calls with an error for bogus path', function(done) {
     fs.promises.readdir('bogus').then(
+      function() {
+        assert.fail('should not succeed.');
+        done();
+      },
+      function(err) {
+        assert.instanceOf(err, Error);
+        done();
+      }
+    );
+  });
+
+  it('calls with an error for restricted path', function(done) {
+    fs.readdir('denied', function(err, items) {
+      assert.instanceOf(err, Error);
+      assert.isUndefined(items);
+      done();
+    });
+  });
+
+  withPromise.it('promise calls with an error for restricted path', function(
+    done
+  ) {
+    fs.promises.readdir('denied').then(
       function() {
         assert.fail('should not succeed.');
         done();
@@ -214,6 +245,18 @@ describe('fs.readdirSync(path)', function() {
   it('throws for bogus path', function() {
     assert.throws(function() {
       fs.readdirSync('bogus');
+    });
+  });
+
+  it('throws when access refused', function() {
+    assert.throws(function() {
+      fs.readdirSync('denied');
+    });
+  });
+
+  it('throws when access refused', function() {
+    assert.throws(function() {
+      fs.readdirSync('denied');
     });
   });
 });

--- a/test/lib/fs.readdir.spec.js
+++ b/test/lib/fs.readdir.spec.js
@@ -253,10 +253,4 @@ describe('fs.readdirSync(path)', function() {
       fs.readdirSync('denied');
     });
   });
-
-  it('throws when access refused', function() {
-    assert.throws(function() {
-      fs.readdirSync('denied');
-    });
-  });
 });


### PR DESCRIPTION
This PR adds access checks to `readdir`and `readdirSync` calls.

This should fix #294 