### PR TITLE
fix: synchronize patching binding/createWriteStream/cwd/chdir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,9 @@ function overrideCreateWriteStream() {
   fs.createWriteStream = function(path, options) {
     const output = realCreateWriteStream(path, options);
     // disable _writev, this will over shadow WriteStream.prototype._writev
-    output._writev = undefined;
+    if (realBinding._mockedBinding) {
+      output._writev = undefined;
+    }
     return output;
   };
 }
@@ -126,13 +128,20 @@ exports = module.exports = function mock(config, options) {
   let currentPath = process.cwd();
   overrideProcess(
     function cwd() {
-      return currentPath;
+      if (realBinding._mockedBinding) {
+        return currentPath;
+      }
+      return realProcessProps.cwd();
     },
     function chdir(directory) {
-      if (!binding.stat(toNamespacedPath(directory)).isDirectory()) {
-        throw new FSError('ENOTDIR');
+      if (realBinding._mockedBinding) {
+        if (!binding.stat(toNamespacedPath(directory)).isDirectory()) {
+          throw new FSError('ENOTDIR');
+        }
+        currentPath = path.resolve(currentPath, directory);
+      } else {
+        return realProcessProps.chdir(directory);
       }
-      currentPath = path.resolve(currentPath, directory);
     }
   );
 

--- a/test/lib/bypass.spec.js
+++ b/test/lib/bypass.spec.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const helper = require('../helper');
+const fs = require('fs');
+const mock = require('../../lib/index');
+const path = require('path');
+const withPromise = helper.withPromise;
+
+const assert = helper.assert;
+
+describe('mock.bypass()', () => {
+  afterEach(mock.restore);
+
+  it('runs a synchronous function using the real filesystem', () => {
+    mock({'/path/to/file': 'content'});
+
+    assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
+    assert.isNotOk(fs.existsSync(__filename));
+    assert.isOk(mock.bypass(() => fs.existsSync(__filename)));
+
+    assert.isNotOk(fs.existsSync(__filename));
+  });
+
+  it('handles functions that throw', () => {
+    mock({'/path/to/file': 'content'});
+
+    const error = new Error('oops');
+
+    assert.throws(() => {
+      mock.bypass(() => {
+        assert.isFalse(fs.existsSync('/path/to/file'));
+        throw error;
+      });
+    }, error);
+
+    assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
+  });
+
+  it('bypasses patched process.cwd() and process.chdir()', () => {
+    const originalCwd = process.cwd();
+    mock({
+      dir: {}
+    });
+
+    process.chdir('dir');
+    assert.equal(process.cwd(), path.join(originalCwd, 'dir'));
+
+    mock.bypass(() => {
+      assert.equal(process.cwd(), originalCwd);
+      process.chdir('lib');
+      assert.equal(process.cwd(), path.join(originalCwd, 'lib'));
+      process.chdir('..');
+      assert.equal(process.cwd(), originalCwd);
+    });
+    assert.equal(process.cwd(), path.join(originalCwd, 'dir'));
+    mock.restore();
+
+    assert.equal(process.cwd(), originalCwd);
+  });
+
+  withPromise.it('runs an async function using the real filesystem', done => {
+    mock({'/path/to/file': 'content'});
+
+    assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
+    assert.isFalse(fs.existsSync(__filename));
+
+    const promise = mock.bypass(() => fs.promises.stat(__filename));
+    assert.instanceOf(promise, Promise);
+
+    promise
+      .then(stat => {
+        assert.isTrue(stat.isFile());
+        assert.isFalse(fs.existsSync(__filename));
+        done();
+      })
+      .catch(done);
+  });
+
+  withPromise.it('handles promise rejection', done => {
+    mock({'/path/to/file': 'content'});
+
+    assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
+    assert.isFalse(fs.existsSync(__filename));
+
+    const error = new Error('oops');
+
+    const promise = mock.bypass(() => {
+      assert.isTrue(fs.existsSync(__filename));
+      return Promise.reject(error);
+    });
+    assert.instanceOf(promise, Promise);
+
+    promise
+      .then(() => {
+        done(new Error('expected rejection'));
+      })
+      .catch(err => {
+        assert.equal(err, error);
+
+        assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
+        done();
+      });
+  });
+});

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -8,7 +8,6 @@ const path = require('path');
 const File = require('../../lib/file');
 const {fixWin32Permissions} = require('../../lib/item');
 const Directory = require('../../lib/directory');
-const withPromise = helper.withPromise;
 
 const assert = helper.assert;
 const assetsPath = path.resolve(__dirname, '../assets');
@@ -182,79 +181,6 @@ describe('The API', function() {
       const stats = fs.statSync('path/to/link');
       assert.isTrue(stats.isFile());
       assert.equal(String(fs.readFileSync('path/to/link')), 'content');
-    });
-  });
-
-  describe(`mock.bypass()`, () => {
-    afterEach(mock.restore);
-
-    it('runs a synchronous function using the real filesystem', () => {
-      mock({'/path/to/file': 'content'});
-
-      assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
-      assert.isNotOk(fs.existsSync(__filename));
-      assert.isOk(mock.bypass(() => fs.existsSync(__filename)));
-
-      assert.isNotOk(fs.existsSync(__filename));
-    });
-
-    it('handles functions that throw', () => {
-      mock({'/path/to/file': 'content'});
-
-      const error = new Error('oops');
-
-      assert.throws(() => {
-        mock.bypass(() => {
-          assert.isFalse(fs.existsSync('/path/to/file'));
-          throw error;
-        });
-      }, error);
-
-      assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
-    });
-
-    withPromise.it('runs an async function using the real filesystem', done => {
-      mock({'/path/to/file': 'content'});
-
-      assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
-      assert.isFalse(fs.existsSync(__filename));
-
-      const promise = mock.bypass(() => fs.promises.stat(__filename));
-      assert.instanceOf(promise, Promise);
-
-      promise
-        .then(stat => {
-          assert.isTrue(stat.isFile());
-          assert.isFalse(fs.existsSync(__filename));
-          done();
-        })
-        .catch(done);
-    });
-
-    withPromise.it('handles promise rejection', done => {
-      mock({'/path/to/file': 'content'});
-
-      assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
-      assert.isFalse(fs.existsSync(__filename));
-
-      const error = new Error('oops');
-
-      const promise = mock.bypass(() => {
-        assert.isTrue(fs.existsSync(__filename));
-        return Promise.reject(error);
-      });
-      assert.instanceOf(promise, Promise);
-
-      promise
-        .then(() => {
-          done(new Error('expected rejection'));
-        })
-        .catch(err => {
-          assert.equal(err, error);
-
-          assert.equal(fs.readFileSync('/path/to/file', 'utf8'), 'content');
-          done();
-        });
     });
   });
 


### PR DESCRIPTION
All the patches now check same realBinding._mockedBinding. This should
fix the edge cases around the new feature bypass().

follows up #306