### PR TITLE
Replace os.tmpDir with temp-dir to get real paths for temp directories

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const os = require('os');
+const tmpdir = require('temp-dir');
 const path = require('path');
 
 const Directory = require('./directory');
@@ -56,7 +56,7 @@ function FileSystem(options) {
   }
 
   if (createTmp) {
-    defaults.push((os.tmpdir && os.tmpdir()) || os.tmpDir());
+    defaults.push(tmpdir);
   }
 
   defaults.forEach(function(dir) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1839,6 +1839,12 @@
         }
       }
     },
+    "temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-config-tschaub": "^13.1.0",
     "mocha": "^6.1.4",
     "rimraf": "^2.6.3",
-    "semver": "^6.0.0"
+    "semver": "^6.0.0",
+    "temp-dir": "^2.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Some of these breaking changes may be restored in a future release.
 
 Configure the `fs` module so it is backed by an in-memory file system.
 
-Calling `mock` sets up a mock file system with two directories by default: `process.cwd()` and `os.tmpdir()` (or `os.tmpDir()` for older Node).  When called with no arguments, just these two directories are created.  When called with a `config` object, additional files, directories, and symlinks are created.  To avoid creating a directory for `process.cwd()` and `os.tmpdir()`, see the [`options`](#options) below.
+Calling `mock` sets up a mock file system with two directories by default: `process.cwd()` and `os.tmpdir()` (using [`temp-dir`](https://www.npmjs.com/package/temp-dir) to get the real path, not a symlink).  When called with no arguments, just these two directories are created.  When called with a `config` object, additional files, directories, and symlinks are created.  To avoid creating a directory for `process.cwd()` and `os.tmpdir()`, see the [`options`](#options) below.
 
 Property names of the `config` object are interpreted as relative paths to resources (relative from `process.cwd()`).  Property values of the `config` object are interpreted as content or configuration for the generated resources.
 

--- a/test/lib/filesystem.spec.js
+++ b/test/lib/filesystem.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const os = require('os');
+const tmpdir = require('temp-dir');
 const path = require('path');
 
 const Directory = require('../../lib/directory');
@@ -25,12 +25,11 @@ describe('FileSystem', function() {
     });
 
     it('accepts a createTmp option', function() {
-      const tmp = os.tmpdir ? os.tmpdir() : os.tmpDir();
       const withTmp = new FileSystem({createTmp: true});
       const withoutTmp = new FileSystem({createTmp: false});
 
-      assert.instanceOf(withTmp.getItem(tmp), Directory);
-      assert.isNull(withoutTmp.getItem(tmp));
+      assert.instanceOf(withTmp.getItem(tmpdir), Directory);
+      assert.isNull(withoutTmp.getItem(tmpdir));
     });
   });
 
@@ -167,15 +166,14 @@ describe('FileSystem.create', function() {
 
   it('passes options to the FileSystem constructor', function() {
     const cwd = process.cwd();
-    const tmp = os.tmpdir ? os.tmpdir() : os.tmpDir();
 
     const withoutCwd = FileSystem.create({}, {createCwd: false});
     const withoutTmp = FileSystem.create({}, {createTmp: false});
 
     assert.isNull(withoutCwd.getItem(cwd));
-    assert.instanceOf(withoutCwd.getItem(tmp), Directory);
+    assert.instanceOf(withoutCwd.getItem(tmpdir), Directory);
 
-    assert.isNull(withoutTmp.getItem(tmp));
+    assert.isNull(withoutTmp.getItem(tmpdir));
     assert.instanceOf(withoutTmp.getItem(cwd), Directory);
   });
 

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -3,7 +3,7 @@
 const helper = require('../helper');
 const fs = require('fs');
 const mock = require('../../lib/index');
-const os = require('os');
+const tmpdir = require('temp-dir');
 const path = require('path');
 const File = require('../../lib/file');
 const {fixWin32Permissions} = require('../../lib/item');
@@ -36,15 +36,7 @@ describe('The API', function() {
       mock();
 
       assert.isTrue(fs.statSync(process.cwd()).isDirectory());
-      let tmp;
-      if (os.tmpdir) {
-        tmp = os.tmpdir();
-      } else if (os.tmpDir) {
-        tmp = os.tmpDir();
-      }
-      if (tmp) {
-        assert.isTrue(fs.statSync(tmp).isDirectory());
-      }
+      assert.isTrue(fs.statSync(tmpdir).isDirectory());
 
       mock.restore();
     });
@@ -60,15 +52,7 @@ describe('The API', function() {
     it('passes the createTmp option to the FileSystem constructor', function() {
       mock({}, {createTmp: false});
 
-      let tmp;
-      if (os.tmpdir) {
-        tmp = os.tmpdir();
-      } else if (os.tmpDir) {
-        tmp = os.tmpDir();
-      }
-      if (tmp) {
-        assert.isFalse(fs.existsSync(tmp));
-      }
+      assert.isFalse(fs.existsSync(tmpdir));
 
       mock.restore();
     });


### PR DESCRIPTION
**Why**

Since `os.tmpDir` doesn't return the actual path to the temp directory (i.e. MacOS), it is unable to use this library together with a library needs to access the actual path of the temp directory.

**How**

This pull request replaces `os.tmpdir()` with `temp-dir` library to achieve the object because the library returns the real path of the temp directory (i.e. `/private/var` instead of `/var` on MacOS).