### PR TITLE
fix: uvBinding.errmap is undefined in Nodejs v12+

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -7,7 +7,7 @@ const uvBinding = process.binding('uv');
  */
 const codes = {};
 
-uvBinding.errmap.forEach(function(value, errno) {
+uvBinding.getErrorMap().forEach(function(value, errno) {
   const code = value[0];
   const message = value[1];
   codes[code] = {errno: errno, message: message};


### PR DESCRIPTION
No idea why this did not fail in test/lib/binding.spec.js, a log of
uvBinding.errmap did yield the error map (maybe mocha patched it??).
It's very hard runtime error when using mock-fs 5.0.0-beta.1