### PR TITLE
Add support for Node.js v16.3.0+

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -6,7 +6,7 @@ const File = require('./file');
 const FileDescriptor = require('./descriptor');
 const Directory = require('./directory');
 const SymbolicLink = require('./symlink');
-const FSError = require('./error');
+const {FSError} = require('./error');
 const constants = require('constants');
 const getPathParts = require('./filesystem').getPathParts;
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -50,6 +50,7 @@ function AbortError() {
   this.name = 'AbortError';
   Error.captureStackTrace(this, AbortError);
 }
+AbortError.prototype = new Error();
 
 /**
  * FSError constructor.

--- a/lib/error.js
+++ b/lib/error.js
@@ -41,6 +41,17 @@ FSError.prototype = new Error();
 FSError.codes = codes;
 
 /**
+ * Creates an abort error for when an asynchronous task was aborted.
+ */
+function AbortError() {
+  Error.call(this);
+  this.code = 'ABORT_ERR';
+  this.name = 'AbortError';
+  Error.captureStackTrace(this, AbortError);
+}
+
+/**
  * Error constructor.
  */
-exports = module.exports = FSError;
+exports.FSError = FSError;
+exports.AbortError = AbortError;

--- a/lib/error.js
+++ b/lib/error.js
@@ -41,7 +41,8 @@ FSError.prototype = new Error();
 FSError.codes = codes;
 
 /**
- * Creates an abort error for when an asynchronous task was aborted.
+ * Create an abort error for when an asynchronous task was aborted.
+ * @constructor
  */
 function AbortError() {
   Error.call(this);
@@ -51,7 +52,10 @@ function AbortError() {
 }
 
 /**
- * Error constructor.
+ * FSError constructor.
  */
 exports.FSError = FSError;
+/**
+ * AbortError constructor.
+ */
 exports.AbortError = AbortError;

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const Directory = require('./directory');
 const File = require('./file');
-const FSError = require('./error');
+const {FSError} = require('./error');
 const SymbolicLink = require('./symlink');
 
 const isWindows = process.platform === 'win32';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,16 @@
 'use strict';
 
 const Binding = require('./binding');
-const FSError = require('./error');
+const {FSError} = require('./error');
 const FileSystem = require('./filesystem');
 const realBinding = process.binding('fs');
 const path = require('path');
 const loader = require('./loader');
 const bypass = require('./bypass');
+const {
+  getReadFileContextPrototype,
+  patchReadFileContext
+} = require('./readfilecontext');
 const fs = require('fs');
 
 const toNamespacedPath = FileSystem.toNamespacedPath;
@@ -49,6 +53,10 @@ for (const key in Binding.prototype) {
     }
   }
 }
+
+const readFileContextPrototype = getReadFileContextPrototype();
+
+patchReadFileContext(readFileContextPrototype);
 
 function overrideBinding(binding) {
   realBinding._mockedBinding = binding;
@@ -94,6 +102,10 @@ function overrideCreateWriteStream() {
   };
 }
 
+function overrideReadFileContext(binding) {
+  readFileContextPrototype._mockedBinding = binding;
+}
+
 function restoreBinding() {
   delete realBinding._mockedBinding;
   realBinding.Stats = realStats;
@@ -110,6 +122,10 @@ function restoreCreateWriteStream() {
   fs.createWriteStream = realCreateWriteStream;
 }
 
+function restoreReadFileContext(binding) {
+  delete readFileContextPrototype._mockedBinding;
+}
+
 /**
  * Swap out the fs bindings for a mock file system.
  * @param {Object} config Mock file system configuration.
@@ -124,6 +140,8 @@ exports = module.exports = function mock(config, options) {
   const binding = new Binding(system);
 
   overrideBinding(binding);
+
+  overrideReadFileContext(binding);
 
   let currentPath = process.cwd();
   overrideProcess(
@@ -167,6 +185,7 @@ exports.restore = function() {
   restoreBinding();
   restoreProcess();
   restoreCreateWriteStream();
+  restoreReadFileContext();
 };
 
 /**

--- a/lib/readfilecontext.js
+++ b/lib/readfilecontext.js
@@ -3,10 +3,12 @@
 const {AbortError} = require('./error');
 const {FSReqCallback} = process.binding('fs');
 
-const kReadFileUnknownBufferLength = 64 * 1024;
-const kReadFileBufferLength = 512 * 1024;
-
-function getReadFileContextPrototype() {
+/**
+ * This is a workaround for getting access to the ReadFileContext
+ * prototype, which we need to be able to patch its methods.
+ * @returns {object}
+ */
+exports.getReadFileContextPrototype = function() {
   const fs = require('fs');
   const fsBinding = process.binding('fs');
 
@@ -22,11 +24,26 @@ function getReadFileContextPrototype() {
   fsBinding.open = originalOpen;
 
   return proto;
-}
+};
 
-function patchReadFileContext(prototype) {
+/**
+ * This patches the ReadFileContext prototype to use mocked bindings
+ * when available. This entire implementation is more or less fully
+ * copied over from Node.js's /lib/internal/fs/read_file_context.js
+ *
+ * This patch is required to support Node.js v16+, where the ReadFileContext
+ * closes directly over the internal fs bindings, and is also eagerly loader.
+ *
+ * See https://github.com/tschaub/mock-fs/issues/332 for more information.
+ *
+ * @param {object} prototype The ReadFileContext prototype object to patch.
+ */
+exports.patchReadFileContext = function(prototype) {
   const origRead = prototype.read;
   const origClose = prototype.close;
+
+  const kReadFileUnknownBufferLength = 64 * 1024;
+  const kReadFileBufferLength = 512 * 1024;
 
   function readFileAfterRead(err, bytesRead) {
     const context = this.context;
@@ -57,6 +74,7 @@ function patchReadFileContext(prototype) {
     let buffer = null;
 
     if (context.err || err) {
+      // This is a simplification from Node.js, where we don't bother merging the errors
       return callback(context.err || err);
     }
 
@@ -106,6 +124,9 @@ function patchReadFileContext(prototype) {
     req.oncomplete = readFileAfterRead;
     req.context = this;
 
+    // This call and the one in close() is what we want to change, the
+    // rest is pretty much the same as Node.js except we don't have access
+    // to some of the internal optimizations.
     prototype._mockedBinding.read(this.fd, buffer, offset, length, -1, req);
   };
 
@@ -128,8 +149,4 @@ function patchReadFileContext(prototype) {
 
     prototype._mockedBinding.close(this.fd, req);
   };
-}
-
-exports.patchReadFileContext = patchReadFileContext;
-
-exports.getReadFileContextPrototype = getReadFileContextPrototype;
+};

--- a/lib/readfilecontext.js
+++ b/lib/readfilecontext.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const {AbortError} = require('./error');
+const {FSReqCallback} = process.binding('fs');
+
+const kReadFileUnknownBufferLength = 64 * 1024;
+const kReadFileBufferLength = 512 * 1024;
+
+function getReadFileContextPrototype() {
+  const fs = require('fs');
+  const fsBinding = process.binding('fs');
+
+  const originalOpen = fsBinding.open;
+
+  let proto;
+  fsBinding.open = (_path, _flags, _mode, req) => {
+    proto = Object.getPrototypeOf(req.context);
+  };
+
+  fs.readFile('/ignored.txt', () => {});
+
+  fsBinding.open = originalOpen;
+
+  return proto;
+}
+
+function patchReadFileContext(prototype) {
+  const origRead = prototype.read;
+  const origClose = prototype.close;
+
+  function readFileAfterRead(err, bytesRead) {
+    const context = this.context;
+
+    if (err) {
+      return context.close(err);
+    }
+    context.pos += bytesRead;
+
+    if (context.pos === context.size || bytesRead === 0) {
+      context.close();
+    } else {
+      if (context.size === 0) {
+        // Unknown size, just read until we don't get bytes.
+        const buffer =
+          bytesRead === kReadFileUnknownBufferLength
+            ? context.buffer
+            : context.buffer.slice(0, bytesRead);
+        Array.prototype.push.apply(context.buffers, buffer);
+      }
+      context.read();
+    }
+  }
+
+  function readFileAfterClose(err) {
+    const context = this.context;
+    const callback = context.callback;
+    let buffer = null;
+
+    if (context.err || err) {
+      return callback(context.err || err);
+    }
+
+    try {
+      if (context.size === 0) {
+        buffer = Buffer.concat(context.buffers, context.pos);
+      } else if (context.pos < context.size) {
+        buffer = context.buffer.slice(0, context.pos);
+      } else {
+        buffer = context.buffer;
+      }
+
+      if (context.encoding) {
+        buffer = buffer.toString(context.encoding);
+      }
+    } catch (err) {
+      return callback(err);
+    }
+
+    callback(null, buffer);
+  }
+
+  prototype.read = function read() {
+    if (!prototype._mockedBinding) {
+      return origRead.apply(this, arguments);
+    }
+
+    let buffer;
+    let offset;
+    let length;
+
+    if (this.signal && this.signal.aborted) {
+      return this.close(new AbortError());
+    }
+    if (this.size === 0) {
+      buffer = Buffer.allocUnsafeSlow(kReadFileUnknownBufferLength);
+      offset = 0;
+      length = kReadFileUnknownBufferLength;
+      this.buffer = buffer;
+    } else {
+      buffer = this.buffer;
+      offset = this.pos;
+      length = Math.min(kReadFileBufferLength, this.size - this.pos);
+    }
+
+    const req = new FSReqCallback();
+    req.oncomplete = readFileAfterRead;
+    req.context = this;
+
+    prototype._mockedBinding.read(this.fd, buffer, offset, length, -1, req);
+  };
+
+  prototype.close = function close(err) {
+    if (!prototype._mockedBinding) {
+      return origClose.apply(this, arguments);
+    }
+
+    if (this.isUserFd) {
+      process.nextTick(function tick(context) {
+        readFileAfterClose.apply({context}, [null]);
+      }, this);
+      return;
+    }
+
+    const req = new FSReqCallback();
+    req.oncomplete = readFileAfterClose;
+    req.context = this;
+    this.err = err;
+
+    prototype._mockedBinding.close(this.fd, req);
+  };
+}
+
+exports.patchReadFileContext = patchReadFileContext;
+
+exports.getReadFileContextPrototype = getReadFileContextPrototype;

--- a/lib/readfilecontext.js
+++ b/lib/readfilecontext.js
@@ -62,7 +62,7 @@ exports.patchReadFileContext = function(prototype) {
           bytesRead === kReadFileUnknownBufferLength
             ? context.buffer
             : context.buffer.slice(0, bytesRead);
-        Array.prototype.push.apply(context.buffers, buffer);
+        context.buffers.push(buffer);
       }
       context.read();
     }

--- a/test/lib/readfilecontext.js
+++ b/test/lib/readfilecontext.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const helper = require('../helper');
+const {
+  patchReadFileContext,
+  getReadFileContextPrototype
+} = require('../../lib/readfilecontext');
+
+const assert = helper.assert;
+
+describe('getReadFileContextPrototype', function() {
+  it('provides access to the internal ReadFileContext', function() {
+    const proto = getReadFileContextPrototype();
+    assert.equal(proto.constructor.name, 'ReadFileContext');
+    assert.equal(typeof proto.read, 'function');
+    assert.equal(typeof proto.close, 'function');
+  });
+});
+
+describe('patchReadFileContext', function() {
+  it('patch forwards calls to mocked binding when available', function() {
+    const calls = {
+      read: 0,
+      close: 0,
+      mockedRead: 0,
+      mockedClose: 0
+    };
+
+    const proto = {
+      read: function() {
+        calls.read++;
+      },
+      close: function() {
+        calls.close++;
+      }
+    };
+
+    const mockedBinding = {
+      read: function() {
+        assert.strictEqual(this, mockedBinding);
+        calls.mockedRead++;
+      },
+      close: function() {
+        assert.strictEqual(this, mockedBinding);
+        calls.mockedClose++;
+      }
+    };
+
+    patchReadFileContext(proto);
+
+    const target = Object.create(proto);
+
+    assert.deepEqual(calls, {
+      read: 0,
+      close: 0,
+      mockedRead: 0,
+      mockedClose: 0
+    });
+
+    target.read();
+    assert.deepEqual(calls, {
+      read: 1,
+      close: 0,
+      mockedRead: 0,
+      mockedClose: 0
+    });
+    target.close();
+    assert.deepEqual(calls, {
+      read: 1,
+      close: 1,
+      mockedRead: 0,
+      mockedClose: 0
+    });
+
+    proto._mockedBinding = mockedBinding;
+    target.read();
+    assert.deepEqual(calls, {
+      read: 1,
+      close: 1,
+      mockedRead: 1,
+      mockedClose: 0
+    });
+    target.close();
+    assert.deepEqual(calls, {
+      read: 1,
+      close: 1,
+      mockedRead: 1,
+      mockedClose: 1
+    });
+
+    delete proto._mockedBinding;
+    target.read();
+    assert.deepEqual(calls, {
+      read: 2,
+      close: 1,
+      mockedRead: 1,
+      mockedClose: 1
+    });
+    target.close();
+    assert.deepEqual(calls, {
+      read: 2,
+      close: 2,
+      mockedRead: 1,
+      mockedClose: 1
+    });
+  });
+});


### PR DESCRIPTION
Hoping to fix #332 with this

Large parts of the implementation in `readfilecontext.js` are copied straight from the Node.js internals. I'm assuming that is all fine as it's already called out in the licence file that parts of this project are copied from there.
