### PR TITLE
Fix source of open FSREQCALLBACK handles 

### DIFF
--- a/lib/readfilecontext.js
+++ b/lib/readfilecontext.js
@@ -17,6 +17,7 @@ exports.getReadFileContextPrototype = function() {
   let proto;
   fsBinding.open = (_path, _flags, _mode, req) => {
     proto = Object.getPrototypeOf(req.context);
+    originalOpen.apply(fsBinding, [_path, _flags, _mode, req]);
   };
 
   fs.readFile('/ignored.txt', () => {});

--- a/lib/readfilecontext.js
+++ b/lib/readfilecontext.js
@@ -17,7 +17,7 @@ exports.getReadFileContextPrototype = function() {
   let proto;
   fsBinding.open = (_path, _flags, _mode, req) => {
     proto = Object.getPrototypeOf(req.context);
-    originalOpen.apply(fsBinding, [_path, _flags, _mode, req]);
+    return originalOpen.apply(fsBinding, [_path, _flags, _mode, req]);
   };
 
   fs.readFile('/ignored.txt', () => {});


### PR DESCRIPTION
Closes https://github.com/tschaub/mock-fs/issues/341

When collecting the prototype for `ReadFileContext` the original fsBinding.open should still be called so that FS read operations can be handled as usual.