### PR TITLE
Document mock options as an optional parameter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,13 +129,13 @@ function restoreReadFileContext(binding) {
 /**
  * Swap out the fs bindings for a mock file system.
  * @param {Object} config Mock file system configuration.
- * @param {Object} options Any filesystem options.
+ * @param {Object} [options={}] Any filesystem options.
  * @param {boolean} options.createCwd Create a directory for `process.cwd()`
  *     (defaults to `true`).
  * @param {boolean} options.createTmp Create a directory for `os.tmpdir()`
  *     (defaults to `true`).
  */
-exports = module.exports = function mock(config, options) {
+exports = module.exports = function mock(config, options = {}) {
   const system = FileSystem.create(config, options);
   const binding = new Binding(system);
 


### PR DESCRIPTION
The `mock` method currently documents its `options` parameter as being required. This causes annoying code inspection errors in the IDE when passing only a single object as folows:

```js
mock({
  "some-directory": {
    "some-file.txt": "file content"
  }
});
```

![image](https://user-images.githubusercontent.com/2468703/154859277-a32be1da-66be-4789-b1bd-6d1210567b72.png)

This change makes the parameter optional as intended.