### PR TITLE
fix: TypeError: Cannot convert  to a BigInt

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -273,8 +273,8 @@ Binding.prototype.realpath = function (filepath, encoding, callback, ctx) {
   });
 };
 
-function fillStats(stats) {
-  const target = stats instanceof Float64Array ? statValues : bigintStatValues;
+function fillStats(stats, bigint) {
+  const target = bigint ? bigintStatValues : statValues;
   for (let i = 0; i < 36; i++) {
     target[i] = stats[i];
   }
@@ -303,7 +303,7 @@ Binding.prototype.stat = function (filepath, bigint, callback, ctx) {
       throw new FSError('ENOENT', filepath);
     }
     const stats = item.getStats(bigint);
-    fillStats(stats);
+    fillStats(stats, bigint);
     return stats;
   });
 };
@@ -323,7 +323,7 @@ Binding.prototype.fstat = function (fd, bigint, callback, ctx) {
     const descriptor = this.getDescriptorById(fd);
     const item = descriptor.getItem();
     const stats = item.getStats(bigint);
-    fillStats(stats);
+    fillStats(stats, bigint);
     return stats;
   });
 };
@@ -1252,7 +1252,7 @@ Binding.prototype.lstat = function (filepath, bigint, callback, ctx) {
       throw new FSError('ENOENT', filepath);
     }
     const stats = item.getStats(bigint);
-    fillStats(stats);
+    fillStats(stats, bigint);
     return stats;
   });
 };


### PR DESCRIPTION
this is a little fix for for an typeError i got with jest on node 16.7.0