### PR TITLE
Reset initial counter state back to 0

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -150,7 +150,7 @@ function Binding(system) {
    * Counter for file descriptors.
    * @type {number}
    */
-  this._counter = -1;
+  this._counter = 0;
 
   const stdin = new FileDescriptor(constants.O_RDWR);
   stdin.setItem(new File.StandardInput());


### PR DESCRIPTION
https://github.com/tschaub/mock-fs/pull/322 fixed some issues with `tape`, but introduced a new one: the node process exits with a non-zero code in some scenarios. I believe [this change](https://github.com/tschaub/mock-fs/pull/322/files#diff-f003d52cb508b6a198d1aac361680301de0b3c0a9f800b3d3230da2923029322R271) is responsible for that, and reverting it fixes the issue for me.