### PR TITLE
fix: fix EACCES error on access by root user

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -1325,19 +1325,14 @@ Binding.prototype.access = function (filepath, mode, callback, ctx) {
       throw new FSError('ENOENT', filepath);
     }
     if (mode && process.getuid && process.getgid) {
-      const itemMode = item.getMode();
-      if (item.getUid() === process.getuid()) {
-        if ((itemMode & (mode * 64)) !== mode * 64) {
-          throw new FSError('EACCES', filepath);
-        }
-      } else if (item.getGid() === process.getgid()) {
-        if ((itemMode & (mode * 8)) !== mode * 8) {
-          throw new FSError('EACCES', filepath);
-        }
-      } else {
-        if ((itemMode & mode) !== mode) {
-          throw new FSError('EACCES', filepath);
-        }
+      if (mode & constants.R_OK && !item.canRead()) {
+        throw new FSError('EACCES', filepath);
+      }
+      if (mode & constants.W_OK && !item.canWrite()) {
+        throw new FSError('EACCES', filepath);
+      }
+      if (mode & constants.X_OK && !item.canExecute()) {
+        throw new FSError('EACCES', filepath);
       }
     }
   });

--- a/test/lib/binding.spec.js
+++ b/test/lib/binding.spec.js
@@ -1625,6 +1625,14 @@ describe('Binding', function () {
   });
 
   describe('#access()', function () {
+    const originalGetuid = process.getuid;
+    const originalGetgid = process.getgid;
+
+    beforeEach(function () {
+      process.getuid = originalGetuid;
+      process.getgid = originalGetgid;
+    });
+
     it('works if file exists', function () {
       const binding = new Binding(system);
       const pathname = path.join('mock-dir', 'one-link.txt');
@@ -1639,7 +1647,7 @@ describe('Binding', function () {
       }, /ENOENT/);
     });
 
-    if (process.getuid && process.getgid) {
+    if (originalGetuid && originalGetgid) {
       it('fails in case of insufficient user permissions', function () {
         const binding = new Binding(system);
         const item = system.getItem(path.join('mock-dir', 'one.txt'));
@@ -1668,6 +1676,16 @@ describe('Binding', function () {
         assert.throws(function () {
           binding.access(path.join('mock-dir', 'one.txt'), 5);
         }, /EACCES/);
+      });
+
+      it('sould not throw if process runs as root', function () {
+        const binding = new Binding(system);
+        const item = system.getItem(path.join('mock-dir', 'one.txt'));
+        item.setUid(42);
+        item.setGid(42);
+        item.setMode(parseInt('0000', 8));
+        process.getuid = () => 0;
+        binding.access(path.join('mock-dir', 'one.txt'), 5);
       });
     }
 

--- a/test/lib/item.spec.js
+++ b/test/lib/item.spec.js
@@ -139,11 +139,15 @@ describe('Item', function () {
   });
 
   if (process.getgid && process.getuid) {
-    const uid = process.getuid();
-    const gid = process.getgid();
+    const originalGetuid = process.getuid;
+    const originalGetgid = process.getgid;
+    const uid = originalGetuid();
+    const gid = originalGetgid();
 
     let item;
     beforeEach(function () {
+      process.getuid = originalGetuid;
+      process.getgid = originalGetgid;
       item = new Item();
     });
 
@@ -218,6 +222,14 @@ describe('Item', function () {
         item.setUid(uid + 1);
         item.setGid(gid + 1);
         item.setMode(parseInt('0777', 8));
+        assert.isTrue(item.canRead());
+      });
+
+      it('always returns true if process runs as root', function () {
+        process.getuid = () => 0;
+        item.setUid(42);
+        item.setGid(42);
+        item.setMode(parseInt('0000', 8));
         assert.isTrue(item.canRead());
       });
     });
@@ -295,6 +307,14 @@ describe('Item', function () {
         item.setMode(parseInt('0777', 8));
         assert.isTrue(item.canWrite());
       });
+
+      it('always returns true if process runs as root', function () {
+        process.getuid = () => 0;
+        item.setUid(42);
+        item.setGid(42);
+        item.setMode(parseInt('0000', 8));
+        assert.isTrue(item.canWrite());
+      });
     });
 
     describe('#canExecute()', function () {
@@ -368,6 +388,14 @@ describe('Item', function () {
         item.setUid(uid + 1);
         item.setGid(gid + 1);
         item.setMode(parseInt('0777', 8));
+        assert.isTrue(item.canExecute());
+      });
+
+      it('always returns true if process runs as root', function () {
+        process.getuid = () => 0;
+        item.setUid(42);
+        item.setGid(42);
+        item.setMode(parseInt('0000', 8));
         assert.isTrue(item.canExecute());
       });
     });


### PR DESCRIPTION
This PR comes to fix an error with the `access` function what does not implement a check for a root user. To fix this I'm reusing the logic already implemented in `canRead`, `canWrite` and `canExecute` functions (I've also added tests for those cases in `item.spec.js`).
I've added test for the error case to `bindings.spec.js`.

P.S. Since, there is no mocking library currently used in the project, so i've used a manual method to mock `process.getuid` and `process.getgid` functions which can easily be replaced by any mocking library.