### PR TITLE
binding: mock readFileSync

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const File = require('./file.js');
 const FileDescriptor = require('./descriptor.js');
@@ -431,6 +432,24 @@ Binding.prototype.openFileHandle = function (pathname, flags, mode, callback) {
       },
     };
   });
+};
+
+/**
+ * This mocks the `readFileSync(path, 'utf8')` optimization
+ * introduced in https://github.com/nodejs/node/pull/48658.
+ *
+ * Rather than implementing the lower level behavior here we
+ * call `readFileSync` again but bypass the optimization.
+ *
+ * The provided flag is ignored for simplicity, as it would
+ * otherwise need to be transformed back intro string format.
+ *
+ * @param {string} pathname File path.
+ * @param {number} flags Flags.
+ * @return {string} The contents of the file
+ */
+Binding.prototype.readFileSync = function (pathname, flags /* ignored */) {
+  return fs.readFileSync(pathname).toString('utf8');
 };
 
 /**


### PR DESCRIPTION
Potential fix for #377

Most of it is explained in the comment, but to reiterate: we can mock the optimized `readFileSync` method introduced in Node v20 by calling the original `readFileSync` but bypassing the optimization by calling `.toString('utf8')` manually afterwards instead.

I figured it's safe to ignore the flag since it's just mocked reads anyway, let's me know if that needs a fix.