### PR TITLE
Stop testing on Node 12 and 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,6 @@ jobs:
           - macos-latest
           - windows-latest
         node:
-          - 12
-          - 14
           - 16
           - 18
 

--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,7 @@ When you require `mock-fs`, Node's own `fs` module is patched to allow the bindi
 
 Mock file access is controlled based on file mode where `process.getuid()` and `process.getgid()` are available (POSIX systems).  On other systems (e.g. Windows) the file mode has no effect.
 
-Tested on Linux, OSX, and Windows using Node 12 through 16.  Check the tickets for a list of [known issues](https://github.com/tschaub/mock-fs/issues).
+Tested on Linux, OSX, and Windows using Node 16 through 18.  Check the tickets for a list of [known issues](https://github.com/tschaub/mock-fs/issues).
 
 ### Using with Jest Snapshot Testing
 


### PR DESCRIPTION
Node 12 and 14 are no longer available in GitHub actions for platform darwin and architecture arm64.