### PR TITLE
fix timeout in failing test

### DIFF
--- a/test/lib/fs.appendFile.spec.js
+++ b/test/lib/fs.appendFile.spec.js
@@ -26,10 +26,13 @@ describe('fs.appendFile(filename, data, [options], callback)', function () {
   });
 
   it('promise writes a string to a new file', function (done) {
-    fs.promises.appendFile('foo', 'bar').then(function () {
-      assert.equal(String(fs.readFileSync('foo')), 'bar');
-      done();
-    }, done);
+    fs.promises
+      .appendFile('foo', 'bar')
+      .then(function () {
+        assert.equal(String(fs.readFileSync('foo')), 'bar');
+        done();
+      })
+      .catch(done);
   });
 
   it('appends a string to an existing file', function (done) {
@@ -43,10 +46,16 @@ describe('fs.appendFile(filename, data, [options], callback)', function () {
   });
 
   it('promise appends a string to an existing file', function (done) {
-    fs.promises.appendFile('dir/file.txt', ' bar').then(function () {
-      assert.equal(String(fs.readFileSync('dir/file.txt')), 'file content bar');
-      done();
-    }, done);
+    fs.promises
+      .appendFile('dir/file.txt', ' bar')
+      .then(function () {
+        assert.equal(
+          String(fs.readFileSync('dir/file.txt')),
+          'file content bar'
+        );
+        done();
+      })
+      .catch(done);
   });
 
   it('appends a buffer to a file', function (done) {
@@ -68,7 +77,8 @@ describe('fs.appendFile(filename, data, [options], callback)', function () {
           'file content bar'
         );
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('appends via a symbolic link file', function (done) {
@@ -82,10 +92,16 @@ describe('fs.appendFile(filename, data, [options], callback)', function () {
   });
 
   it('promise appends via a symbolic link file', function (done) {
-    fs.promises.appendFile('link.txt', ' bar').then(function () {
-      assert.equal(String(fs.readFileSync('dir/file.txt')), 'file content bar');
-      done();
-    }, done);
+    fs.promises
+      .appendFile('link.txt', ' bar')
+      .then(function () {
+        assert.equal(
+          String(fs.readFileSync('dir/file.txt')),
+          'file content bar'
+        );
+        done();
+      })
+      .catch(done);
   });
 
   it('fails if directory does not exist', function (done) {

--- a/test/lib/fs.chmod-fchmod.spec.js
+++ b/test/lib/fs.chmod-fchmod.spec.js
@@ -37,11 +37,14 @@ describe('fs.chmod(path, mode, callback)', function () {
   });
 
   it('promise changes permissions of a file', function (done) {
-    fs.promises.chmod('file.txt', parseInt('0664', 8)).then(function () {
-      const stats = fs.statSync('file.txt');
-      assert.equal(stats.mode & parseInt('0777', 8), parseInt('0664', 8));
-      done();
-    }, done);
+    fs.promises
+      .chmod('file.txt', parseInt('0664', 8))
+      .then(function () {
+        const stats = fs.statSync('file.txt');
+        assert.equal(stats.mode & parseInt('0777', 8), parseInt('0664', 8));
+        done();
+      })
+      .catch(done);
   });
 
   it('fails if file does not exist', function (done) {
@@ -117,7 +120,8 @@ describe('fs.fchmod(fd, mode, callback)', function () {
         const stats = fs.statSync('file.txt');
         assert.equal(stats.mode & parseInt('0777', 8), parseInt('0644', 8));
         done();
-      }, done);
+      })
+      .catch(done);
   });
 });
 

--- a/test/lib/fs.copyFile.spec.js
+++ b/test/lib/fs.copyFile.spec.js
@@ -52,7 +52,8 @@ if (fs.copyFile && fs.copyFileSync) {
             'file content'
           );
           done();
-        }, done);
+        })
+        .catch(done);
     });
 
     it('truncates dest file if it exists', function (done) {
@@ -75,7 +76,8 @@ if (fs.copyFile && fs.copyFileSync) {
             'file content'
           );
           done();
-        }, done);
+        })
+        .catch(done);
     });
 
     it('throws if dest exists and exclusive', function (done) {

--- a/test/lib/fs.link-symlink.spec.js
+++ b/test/lib/fs.link-symlink.spec.js
@@ -49,13 +49,16 @@ describe('fs.link(srcpath, dstpath, callback)', function () {
   it('promise creates a link to a file', function (done) {
     assert.equal(fs.statSync('file.txt').nlink, 1);
 
-    fs.promises.link('file.txt', 'link.txt').then(function () {
-      assert.isTrue(fs.statSync('link.txt').isFile());
-      assert.equal(fs.statSync('link.txt').nlink, 2);
-      assert.equal(fs.statSync('file.txt').nlink, 2);
-      assert.equal(String(fs.readFileSync('link.txt')), 'content');
-      done();
-    }, done);
+    fs.promises
+      .link('file.txt', 'link.txt')
+      .then(function () {
+        assert.isTrue(fs.statSync('link.txt').isFile());
+        assert.equal(fs.statSync('link.txt').nlink, 2);
+        assert.equal(fs.statSync('file.txt').nlink, 2);
+        assert.equal(String(fs.readFileSync('link.txt')), 'content');
+        done();
+      })
+      .catch(done);
   });
 
   it('works if original is renamed', function (done) {
@@ -71,12 +74,15 @@ describe('fs.link(srcpath, dstpath, callback)', function () {
   });
 
   it('promise works if original is renamed', function (done) {
-    fs.promises.link('file.txt', 'link.txt').then(function () {
-      fs.renameSync('file.txt', 'renamed.txt');
-      assert.isTrue(fs.statSync('link.txt').isFile());
-      assert.equal(String(fs.readFileSync('link.txt')), 'content');
-      done();
-    }, done);
+    fs.promises
+      .link('file.txt', 'link.txt')
+      .then(function () {
+        fs.renameSync('file.txt', 'renamed.txt');
+        assert.isTrue(fs.statSync('link.txt').isFile());
+        assert.equal(String(fs.readFileSync('link.txt')), 'content');
+        done();
+      })
+      .catch(done);
   });
 
   it('works if original is removed', function (done) {
@@ -99,15 +105,18 @@ describe('fs.link(srcpath, dstpath, callback)', function () {
   it('promise works if original is removed', function (done) {
     assert.equal(fs.statSync('file.txt').nlink, 1);
 
-    fs.promises.link('file.txt', 'link.txt').then(function () {
-      assert.equal(fs.statSync('link.txt').nlink, 2);
-      assert.equal(fs.statSync('file.txt').nlink, 2);
-      fs.unlinkSync('file.txt');
-      assert.isTrue(fs.statSync('link.txt').isFile());
-      assert.equal(fs.statSync('link.txt').nlink, 1);
-      assert.equal(String(fs.readFileSync('link.txt')), 'content');
-      done();
-    }, done);
+    fs.promises
+      .link('file.txt', 'link.txt')
+      .then(function () {
+        assert.equal(fs.statSync('link.txt').nlink, 2);
+        assert.equal(fs.statSync('file.txt').nlink, 2);
+        fs.unlinkSync('file.txt');
+        assert.isTrue(fs.statSync('link.txt').isFile());
+        assert.equal(fs.statSync('link.txt').nlink, 1);
+        assert.equal(String(fs.readFileSync('link.txt')), 'content');
+        done();
+      })
+      .catch(done);
   });
 
   it('fails if original is a directory', function (done) {
@@ -221,11 +230,14 @@ describe('fs.symlink(srcpath, dstpath, [type], callback)', function () {
   }
 
   it('promise creates a symbolic link to a file', function (done) {
-    fs.promises.symlink('../file.txt', 'dir/link.txt').then(function () {
-      assert.isTrue(fs.statSync('dir/link.txt').isFile());
-      assert.equal(String(fs.readFileSync('dir/link.txt')), 'content');
-      done();
-    }, done);
+    fs.promises
+      .symlink('../file.txt', 'dir/link.txt')
+      .then(function () {
+        assert.isTrue(fs.statSync('dir/link.txt').isFile());
+        assert.equal(String(fs.readFileSync('dir/link.txt')), 'content');
+        done();
+      })
+      .catch(done);
   });
 
   it('breaks if original is renamed', function (done) {
@@ -241,12 +253,15 @@ describe('fs.symlink(srcpath, dstpath, [type], callback)', function () {
   });
 
   it('promise breaks if original is renamed', function (done) {
-    fs.promises.symlink('file.txt', 'link.txt').then(function () {
-      assert.isTrue(fs.existsSync('link.txt'));
-      fs.renameSync('file.txt', 'renamed.txt');
-      assert.isFalse(fs.existsSync('link.txt'));
-      done();
-    }, done);
+    fs.promises
+      .symlink('file.txt', 'link.txt')
+      .then(function () {
+        assert.isTrue(fs.existsSync('link.txt'));
+        fs.renameSync('file.txt', 'renamed.txt');
+        assert.isFalse(fs.existsSync('link.txt'));
+        done();
+      })
+      .catch(done);
   });
 
   it('works if original is a directory', function (done) {
@@ -260,10 +275,13 @@ describe('fs.symlink(srcpath, dstpath, [type], callback)', function () {
   });
 
   it('promise works if original is a directory', function (done) {
-    fs.promises.symlink('dir', 'link').then(function () {
-      assert.isTrue(fs.statSync('link').isDirectory());
-      done();
-    }, done);
+    fs.promises
+      .symlink('dir', 'link')
+      .then(function () {
+        assert.isTrue(fs.statSync('link').isDirectory());
+        done();
+      })
+      .catch(done);
   });
 });
 

--- a/test/lib/fs.lstat.spec.js
+++ b/test/lib/fs.lstat.spec.js
@@ -70,21 +70,27 @@ describe('fs.lstat(path, options, callback)', function () {
   });
 
   it('promise stats a symbolic link', function (done) {
-    fs.promises.lstat('link').then(function (stats) {
-      assert.isTrue(stats.isSymbolicLink());
-      assert.isFalse(stats.isFile());
-      assert.equal(stats.mtime.getTime(), 2);
-      done();
-    }, done);
+    fs.promises
+      .lstat('link')
+      .then(function (stats) {
+        assert.isTrue(stats.isSymbolicLink());
+        assert.isFalse(stats.isFile());
+        assert.equal(stats.mtime.getTime(), 2);
+        done();
+      })
+      .catch(done);
   });
 
   it('promise stats a symbolic link with bigint', function (done) {
-    fs.promises.lstat('link', {bigint: true}).then(function (stats) {
-      assert.isTrue(stats.isSymbolicLink());
-      assert.isFalse(stats.isFile());
-      assert.equal(typeof stats.mtimeMs, 'bigint');
-      done();
-    }, done);
+    fs.promises
+      .lstat('link', {bigint: true})
+      .then(function (stats) {
+        assert.isTrue(stats.isSymbolicLink());
+        assert.isFalse(stats.isFile());
+        assert.equal(typeof stats.mtimeMs, 'bigint');
+        done();
+      })
+      .catch(done);
   });
 
   it('stats a regular file', function (done) {
@@ -112,21 +118,27 @@ describe('fs.lstat(path, options, callback)', function () {
   });
 
   it('promise stats a regular file', function (done) {
-    fs.promises.lstat('file.txt').then(function (stats) {
-      assert.isTrue(stats.isFile());
-      assert.isFalse(stats.isSymbolicLink());
-      assert.equal(stats.mtime.getTime(), 1);
-      done();
-    }, done);
+    fs.promises
+      .lstat('file.txt')
+      .then(function (stats) {
+        assert.isTrue(stats.isFile());
+        assert.isFalse(stats.isSymbolicLink());
+        assert.equal(stats.mtime.getTime(), 1);
+        done();
+      })
+      .catch(done);
   });
 
   it('promise stats a regular file with bigint', function (done) {
-    fs.promises.lstat('file.txt', {bigint: true}).then(function (stats) {
-      assert.isTrue(stats.isFile());
-      assert.isFalse(stats.isSymbolicLink());
-      assert.equal(typeof stats.mtimeMs, 'bigint');
-      done();
-    }, done);
+    fs.promises
+      .lstat('file.txt', {bigint: true})
+      .then(function (stats) {
+        assert.isTrue(stats.isFile());
+        assert.isFalse(stats.isSymbolicLink());
+        assert.equal(typeof stats.mtimeMs, 'bigint');
+        done();
+      })
+      .catch(done);
   });
 
   it('fails on file not exist', function (done) {

--- a/test/lib/fs.mkdir.spec.js
+++ b/test/lib/fs.mkdir.spec.js
@@ -44,11 +44,14 @@ describe('fs.mkdir(path, [mode], callback)', function () {
   });
 
   it('promise creates a new directory', function (done) {
-    fs.promises.mkdir('parent/dir').then(function () {
-      const stats = fs.statSync('parent/dir');
-      assert.isTrue(stats.isDirectory());
-      done();
-    }, done);
+    fs.promises
+      .mkdir('parent/dir')
+      .then(function () {
+        const stats = fs.statSync('parent/dir');
+        assert.isTrue(stats.isDirectory());
+        done();
+      })
+      .catch(done);
   });
 
   it('creates a new directory recursively', function (done) {
@@ -77,7 +80,8 @@ describe('fs.mkdir(path, [mode], callback)', function () {
         stats = fs.statSync('parent/foo');
         assert.isTrue(stats.isDirectory());
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('accepts dir mode', function (done) {
@@ -93,12 +97,15 @@ describe('fs.mkdir(path, [mode], callback)', function () {
   });
 
   it('promise accepts dir mode', function (done) {
-    fs.promises.mkdir('parent/dir', parseInt('0755', 8)).then(function () {
-      const stats = fs.statSync('parent/dir');
-      assert.isTrue(stats.isDirectory());
-      assert.equal(stats.mode & parseInt('0777', 8), parseInt('0755', 8));
-      done();
-    }, done);
+    fs.promises
+      .mkdir('parent/dir', parseInt('0755', 8))
+      .then(function () {
+        const stats = fs.statSync('parent/dir');
+        assert.isTrue(stats.isDirectory());
+        assert.equal(stats.mode & parseInt('0777', 8), parseInt('0755', 8));
+        done();
+      })
+      .catch(done);
   });
 
   it('accepts dir mode recursively', function (done) {
@@ -141,7 +148,8 @@ describe('fs.mkdir(path, [mode], callback)', function () {
         assert.isTrue(stats.isDirectory());
         assert.equal(stats.mode & parseInt('0777', 8), parseInt('0755', 8));
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('fails if parent does not exist', function (done) {

--- a/test/lib/fs.mkdtemp.spec.js
+++ b/test/lib/fs.mkdtemp.spec.js
@@ -34,13 +34,16 @@ if (fs.mkdtemp) {
     });
 
     it('promise creates a new directory', function (done) {
-      fs.promises.mkdtemp('parent/dir').then(function (dirPath) {
-        const parentPath = path.dirname(dirPath);
-        assert.equal(parentPath, 'parent');
-        const stats = fs.statSync(dirPath);
-        assert.isTrue(stats.isDirectory());
-        done();
-      }, done);
+      fs.promises
+        .mkdtemp('parent/dir')
+        .then(function (dirPath) {
+          const parentPath = path.dirname(dirPath);
+          assert.equal(parentPath, 'parent');
+          const stats = fs.statSync(dirPath);
+          assert.isTrue(stats.isDirectory());
+          done();
+        })
+        .catch(done);
     });
 
     it('accepts a "utf8" encoding argument', function (done) {
@@ -58,14 +61,17 @@ if (fs.mkdtemp) {
     });
 
     it('promise accepts a "utf8" encoding argument', function (done) {
-      fs.promises.mkdtemp('parent/dir', 'utf8').then(function (dirPath) {
-        assert.isString(dirPath);
-        const parentPath = path.dirname(dirPath);
-        assert.equal(parentPath, 'parent');
-        const stats = fs.statSync(dirPath);
-        assert.isTrue(stats.isDirectory());
-        done();
-      }, done);
+      fs.promises
+        .mkdtemp('parent/dir', 'utf8')
+        .then(function (dirPath) {
+          assert.isString(dirPath);
+          const parentPath = path.dirname(dirPath);
+          assert.equal(parentPath, 'parent');
+          const stats = fs.statSync(dirPath);
+          assert.isTrue(stats.isDirectory());
+          done();
+        })
+        .catch(done);
     });
 
     it('accepts a "buffer" encoding argument', function (done) {
@@ -84,15 +90,18 @@ if (fs.mkdtemp) {
     });
 
     it('promise accepts a "buffer" encoding argument', function (done) {
-      fs.promises.mkdtemp('parent/dir', 'buffer').then(function (buffer) {
-        assert.instanceOf(buffer, Buffer);
-        const dirPath = buffer.toString();
-        const parentPath = path.dirname(dirPath);
-        assert.equal(parentPath, 'parent');
-        const stats = fs.statSync(dirPath);
-        assert.isTrue(stats.isDirectory());
-        done();
-      }, done);
+      fs.promises
+        .mkdtemp('parent/dir', 'buffer')
+        .then(function (buffer) {
+          assert.instanceOf(buffer, Buffer);
+          const dirPath = buffer.toString();
+          const parentPath = path.dirname(dirPath);
+          assert.equal(parentPath, 'parent');
+          const stats = fs.statSync(dirPath);
+          assert.isTrue(stats.isDirectory());
+          done();
+        })
+        .catch(done);
     });
 
     it('accepts an options argument with "utf8" encoding', function (done) {
@@ -119,7 +128,8 @@ if (fs.mkdtemp) {
           const stats = fs.statSync(dirPath);
           assert.isTrue(stats.isDirectory());
           done();
-        }, done);
+        })
+        .catch(done);
     });
 
     it('accepts an options argument with "buffer" encoding', function (done) {
@@ -148,7 +158,8 @@ if (fs.mkdtemp) {
           const stats = fs.statSync(dirPath);
           assert.isTrue(stats.isDirectory());
           done();
-        }, done);
+        })
+        .catch(done);
     });
 
     it('fails if parent does not exist', function (done) {

--- a/test/lib/fs.open-close.spec.js
+++ b/test/lib/fs.open-close.spec.js
@@ -45,10 +45,13 @@ describe('fs.open(path, flags, [mode], callback)', function () {
   });
 
   it('promise opens an existing file for reading (r)', function (done) {
-    fs.promises.open('nested/sub/dir/one.txt', 'r').then(function (fd) {
-      assert.isNumber(fd.fd);
-      done();
-    }, done);
+    fs.promises
+      .open('nested/sub/dir/one.txt', 'r')
+      .then(function (fd) {
+        assert.isNumber(fd.fd);
+        done();
+      })
+      .catch(done);
   });
 
   it('fails if file does not exist (r)', function (done) {
@@ -90,7 +93,8 @@ describe('fs.open(path, flags, [mode], callback)', function () {
         assert.isNumber(fd.fd);
         assert.isTrue(fs.existsSync('path/to/new.txt'));
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('opens an existing file for writing (w)', function (done) {
@@ -109,7 +113,8 @@ describe('fs.open(path, flags, [mode], callback)', function () {
       .then(function (fd) {
         assert.isNumber(fd.fd);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('fails if file exists (wx)', function (done) {

--- a/test/lib/fs.read.spec.js
+++ b/test/lib/fs.read.spec.js
@@ -44,7 +44,8 @@ describe('fs.read(fd, buffer, offset, length, position, callback)', function () 
         assert.equal(result.buffer, buffer);
         assert.equal(String(buffer), 'file content');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('allows file contents to be read w/ offset', function (done) {
@@ -77,7 +78,8 @@ describe('fs.read(fd, buffer, offset, length, position, callback)', function () 
         assert.equal(result.buffer, buffer);
         assert.equal(String(buffer.slice(5)), 'file co');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('allows file contents to be read w/ length', function (done) {
@@ -110,7 +112,8 @@ describe('fs.read(fd, buffer, offset, length, position, callback)', function () 
         assert.equal(result.buffer, buffer);
         assert.equal(String(buffer.slice(0, 4)), 'file');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('allows file contents to be read w/ offset & length', function (done) {
@@ -143,7 +146,8 @@ describe('fs.read(fd, buffer, offset, length, position, callback)', function () 
         assert.equal(result.buffer, buffer);
         assert.equal(String(buffer.slice(2, 6)), 'file');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('allows file contents to be read w/ position', function (done) {
@@ -176,7 +180,8 @@ describe('fs.read(fd, buffer, offset, length, position, callback)', function () 
         assert.equal(result.buffer, buffer);
         assert.equal(String(buffer), 'content');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('allows read w/ offset, length, & position', function (done) {
@@ -209,7 +214,8 @@ describe('fs.read(fd, buffer, offset, length, position, callback)', function () 
         assert.equal(result.buffer, buffer);
         assert.equal(String(buffer.slice(2, 9)), 'content');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('fails for closed file descriptor', function (done) {

--- a/test/lib/fs.readFile.spec.js
+++ b/test/lib/fs.readFile.spec.js
@@ -29,11 +29,14 @@ describe('fs.readFile(filename, [options], callback)', function () {
   });
 
   it('promise allows a file to be read asynchronously', function (done) {
-    fs.promises.readFile('path/to/file.txt').then(function (data) {
-      assert.isTrue(Buffer.isBuffer(data));
-      assert.equal(String(data), 'file content');
-      done();
-    }, done);
+    fs.promises
+      .readFile('path/to/file.txt')
+      .then(function (data) {
+        assert.isTrue(Buffer.isBuffer(data));
+        assert.equal(String(data), 'file content');
+        done();
+      })
+      .catch(done);
   });
 
   it('fails for directory', function (done) {

--- a/test/lib/fs.readdir.spec.js
+++ b/test/lib/fs.readdir.spec.js
@@ -51,11 +51,14 @@ describe('fs.readdir(path, callback)', function () {
   });
 
   it('promise lists directory contents', function (done) {
-    fs.promises.readdir(path.join('path', 'to')).then(function (items) {
-      assert.isArray(items);
-      assert.deepEqual(items, ['file.txt']);
-      done();
-    }, done);
+    fs.promises
+      .readdir(path.join('path', 'to'))
+      .then(function (items) {
+        assert.isArray(items);
+        assert.deepEqual(items, ['file.txt']);
+        done();
+      })
+      .catch(done);
   });
 
   it('lists nested directory contents', function (done) {
@@ -74,7 +77,8 @@ describe('fs.readdir(path, callback)', function () {
         assert.isArray(items);
         assert.deepEqual(items, ['empty', 'one.txt', 'two.txt']);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('calls with an error for bogus path', function (done) {
@@ -151,7 +155,8 @@ describe('fs.readdir(path, callback)', function () {
         assert.ok(items[1].isFile());
         assert.ok(items[2].isFile());
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('should support "withFileTypes" option with "encoding" option', function (done) {

--- a/test/lib/fs.readlink.spec.js
+++ b/test/lib/fs.readlink.spec.js
@@ -36,10 +36,13 @@ describe('fs.readlink(path, callback)', function () {
   });
 
   it('promise reads a symbolic link', function (done) {
-    fs.promises.readlink('link').then(function (srcPath) {
-      assert.equal(srcPath, './file.txt');
-      done();
-    }, done);
+    fs.promises
+      .readlink('link')
+      .then(function (srcPath) {
+        assert.equal(srcPath, './file.txt');
+        done();
+      })
+      .catch(done);
   });
 
   it('fails for regular files', function (done) {

--- a/test/lib/fs.realpath.spec.js
+++ b/test/lib/fs.realpath.spec.js
@@ -28,10 +28,13 @@ describe('fs.realpath(path, [cache], callback)', function () {
   });
 
   it('promise resolves the real path for a symbolic link', function (done) {
-    fs.promises.realpath('link').then(function (resolved) {
-      assertEqualPaths(resolved, path.resolve('dir/file.txt'));
-      done();
-    }, done);
+    fs.promises
+      .realpath('link')
+      .then(function (resolved) {
+        assertEqualPaths(resolved, path.resolve('dir/file.txt'));
+        done();
+      })
+      .catch(done);
   });
 
   it('resolves the real path regular file', function (done) {
@@ -45,10 +48,13 @@ describe('fs.realpath(path, [cache], callback)', function () {
   });
 
   it('promise resolves the real path regular file', function (done) {
-    fs.promises.realpath('dir/file.txt').then(function (resolved) {
-      assertEqualPaths(resolved, path.resolve('dir/file.txt'));
-      done();
-    }, done);
+    fs.promises
+      .realpath('dir/file.txt')
+      .then(function (resolved) {
+        assertEqualPaths(resolved, path.resolve('dir/file.txt'));
+        done();
+      })
+      .catch(done);
   });
 
   it('fails on file not exist', function (done) {

--- a/test/lib/fs.rename.spec.js
+++ b/test/lib/fs.rename.spec.js
@@ -44,11 +44,14 @@ describe('fs.rename(oldPath, newPath, callback)', function () {
   });
 
   it('promise allows files to be renamed', function (done) {
-    fs.promises.rename('path/to/a.bin', 'path/to/b.bin').then(function () {
-      assert.isFalse(fs.existsSync('path/to/a.bin'));
-      assert.isTrue(fs.existsSync('path/to/b.bin'));
-      done();
-    }, done);
+    fs.promises
+      .rename('path/to/a.bin', 'path/to/b.bin')
+      .then(function () {
+        assert.isFalse(fs.existsSync('path/to/a.bin'));
+        assert.isTrue(fs.existsSync('path/to/b.bin'));
+        done();
+      })
+      .catch(done);
   });
 
   it('updates mtime of parent directory', function (done) {
@@ -73,7 +76,8 @@ describe('fs.rename(oldPath, newPath, callback)', function () {
         const newTime = fs.statSync('nested/dir').mtime;
         assert.isTrue(newTime > oldTime);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('calls callback with error if old path does not exist', function (done) {
@@ -111,7 +115,8 @@ describe('fs.rename(oldPath, newPath, callback)', function () {
         assert.isFalse(fs.existsSync('path/to/a.bin'));
         assert.isTrue(fs.existsSync('nested/dir/file.txt'));
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('allows directories to be renamed', function (done) {
@@ -125,12 +130,15 @@ describe('fs.rename(oldPath, newPath, callback)', function () {
   });
 
   it('promise allows directories to be renamed', function (done) {
-    fs.promises.rename('path/to', 'path/foo').then(function () {
-      assert.isFalse(fs.existsSync('path/to'));
-      assert.isTrue(fs.existsSync('path/foo'));
-      assert.deepEqual(fs.readdirSync('path/foo'), ['a.bin']);
-      done();
-    }, done);
+    fs.promises
+      .rename('path/to', 'path/foo')
+      .then(function () {
+        assert.isFalse(fs.existsSync('path/to'));
+        assert.isTrue(fs.existsSync('path/foo'));
+        assert.deepEqual(fs.readdirSync('path/foo'), ['a.bin']);
+        done();
+      })
+      .catch(done);
   });
 
   it('calls callback with error if new directory not empty', function (done) {

--- a/test/lib/fs.rmdir.spec.js
+++ b/test/lib/fs.rmdir.spec.js
@@ -64,11 +64,14 @@ describe('fs.rmdir(path, callback)', function () {
   it('promise removes an empty directory', function (done) {
     assert.equal(fs.statSync('path/to').nlink, 3);
 
-    fs.promises.rmdir('path/to/empty').then(function () {
-      assert.isFalse(fs.existsSync('path/to/empty'));
-      assert.equal(fs.statSync('path/to').nlink, 2);
-      done();
-    }, done);
+    fs.promises
+      .rmdir('path/to/empty')
+      .then(function () {
+        assert.isFalse(fs.existsSync('path/to/empty'));
+        assert.equal(fs.statSync('path/to').nlink, 2);
+        done();
+      })
+      .catch(done);
   });
 
   it('fails if not empty', function (done) {
@@ -130,11 +133,14 @@ describe('fs.rmdir(path, callback)', function () {
     it('promise recursively remove empty directory', function (done) {
       assert.equal(fs.statSync('path2/to').nlink, 4);
 
-      fs.promises.rmdir('path2/to/empty', {recursive: true}).then(function () {
-        assert.isFalse(fs.existsSync('path2/to/empty'));
-        assert.equal(fs.statSync('path2/to').nlink, 3);
-        done();
-      }, done);
+      fs.promises
+        .rmdir('path2/to/empty', {recursive: true})
+        .then(function () {
+          assert.isFalse(fs.existsSync('path2/to/empty'));
+          assert.equal(fs.statSync('path2/to').nlink, 3);
+          done();
+        })
+        .catch(done);
     });
 
     it('recursively remove non-empty directory', function (done) {
@@ -159,7 +165,8 @@ describe('fs.rmdir(path, callback)', function () {
           assert.isFalse(fs.existsSync('path2/to/non-empty'));
           assert.equal(fs.statSync('path2/to').nlink, 3);
           done();
-        }, done);
+        })
+        .catch(done);
     });
   });
 

--- a/test/lib/fs.stat-fstat.spec.js
+++ b/test/lib/fs.stat-fstat.spec.js
@@ -37,10 +37,13 @@ describe('fs.stat(path, options, callback)', function () {
   });
 
   xit('promise creates an instance of fs.Stats', function (done) {
-    fs.promises.stat('/path/to/file.txt').then(function (stats) {
-      assert.instanceOf(stats, fs.Stats);
-      done();
-    }, done);
+    fs.promises
+      .stat('/path/to/file.txt')
+      .then(function (stats) {
+        assert.instanceOf(stats, fs.Stats);
+        done();
+      })
+      .catch(done);
   });
 
   it('identifies files', function (done) {
@@ -96,12 +99,15 @@ describe('fs.stat(path, options, callback)', function () {
   });
 
   it('promise identifies files', function (done) {
-    fs.promises.stat('/path/to/file.txt').then(function (stats) {
-      assert.isTrue(stats.isFile());
-      assert.isFalse(stats.isDirectory());
-      done();
-      assert.equal(stats.mtime.getTime(), 2);
-    }, done);
+    fs.promises
+      .stat('/path/to/file.txt')
+      .then(function (stats) {
+        assert.isTrue(stats.isFile());
+        assert.isFalse(stats.isDirectory());
+        done();
+        assert.equal(stats.mtime.getTime(), 2);
+      })
+      .catch(done);
   });
 
   it('promise identifies files', function (done) {
@@ -112,7 +118,8 @@ describe('fs.stat(path, options, callback)', function () {
         assert.isFalse(stats.isDirectory());
         done();
         assert.equal(typeof stats.mtimeMs, 'bigint');
-      }, done);
+      })
+      .catch(done);
   });
 
   it('identifies directories', function (done) {
@@ -140,21 +147,27 @@ describe('fs.stat(path, options, callback)', function () {
   });
 
   it('promise identifies directories', function (done) {
-    fs.promises.stat('/empty').then(function (stats) {
-      assert.isTrue(stats.isDirectory());
-      assert.isFalse(stats.isFile());
-      assert.equal(stats.size, 1);
-      done();
-    }, done);
+    fs.promises
+      .stat('/empty')
+      .then(function (stats) {
+        assert.isTrue(stats.isDirectory());
+        assert.isFalse(stats.isFile());
+        assert.equal(stats.size, 1);
+        done();
+      })
+      .catch(done);
   });
 
   it('promise identifies directories with bigint', function (done) {
-    fs.promises.stat('/empty', {bigint: true}).then(function (stats) {
-      assert.isTrue(stats.isDirectory());
-      assert.isFalse(stats.isFile());
-      assert.equal(typeof stats.size, 'bigint');
-      done();
-    }, done);
+    fs.promises
+      .stat('/empty', {bigint: true})
+      .then(function (stats) {
+        assert.isTrue(stats.isDirectory());
+        assert.isFalse(stats.isFile());
+        assert.equal(typeof stats.size, 'bigint');
+        done();
+      })
+      .catch(done);
   });
 
   it('provides file stats', function (done) {
@@ -190,16 +203,19 @@ describe('fs.stat(path, options, callback)', function () {
   });
 
   it('promise provides file stats', function (done) {
-    fs.promises.stat('/path/to/file.txt').then(function (stats) {
-      assert.equal(stats.ctime.getTime(), 1);
-      assert.equal(stats.mtime.getTime(), 2);
-      assert.equal(stats.atime.getTime(), 3);
-      assert.equal(stats.uid, 42);
-      assert.equal(stats.gid, 43);
-      assert.equal(stats.nlink, 1);
-      assert.isNumber(stats.rdev);
-      done();
-    }, done);
+    fs.promises
+      .stat('/path/to/file.txt')
+      .then(function (stats) {
+        assert.equal(stats.ctime.getTime(), 1);
+        assert.equal(stats.mtime.getTime(), 2);
+        assert.equal(stats.atime.getTime(), 3);
+        assert.equal(stats.uid, 42);
+        assert.equal(stats.gid, 43);
+        assert.equal(stats.nlink, 1);
+        assert.isNumber(stats.rdev);
+        done();
+      })
+      .catch(done);
   });
 
   it('promise provides file stats with bigint', function (done) {
@@ -214,7 +230,8 @@ describe('fs.stat(path, options, callback)', function () {
         assert.equal(typeof stats.nlink, 'bigint');
         assert.equal(typeof stats.rdev, 'bigint');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   if (
@@ -235,11 +252,14 @@ describe('fs.stat(path, options, callback)', function () {
     });
 
     it('promise includes blocks and blksize in stats', function (done) {
-      fs.promises.stat('/path/to/file.txt').then(function (stats) {
-        assert.isNumber(stats.blocks);
-        assert.isNumber(stats.blksize);
-        done();
-      }, done);
+      fs.promises
+        .stat('/path/to/file.txt')
+        .then(function (stats) {
+          assert.isNumber(stats.blocks);
+          assert.isNumber(stats.blksize);
+          done();
+        })
+        .catch(done);
     });
   }
 
@@ -292,45 +312,51 @@ describe('fs.stat(path, options, callback)', function () {
   });
 
   it('promise provides directory stats', function (done) {
-    fs.promises.stat('/path').then(function (stats) {
-      assert.instanceOf(stats.ctime, Date);
-      assert.instanceOf(stats.mtime, Date);
-      assert.instanceOf(stats.atime, Date);
-      if (process.getuid) {
-        assert.isNumber(stats.uid);
-      } else {
-        assert.strictEqual(stats.uid, 0);
-      }
-      if (process.getgid) {
-        assert.isNumber(stats.gid);
-      } else {
-        assert.strictEqual(stats.gid, 0);
-      }
-      assert.equal(stats.nlink, 3);
-      assert.isNumber(stats.rdev);
-      done();
-    }, done);
+    fs.promises
+      .stat('/path')
+      .then(function (stats) {
+        assert.instanceOf(stats.ctime, Date);
+        assert.instanceOf(stats.mtime, Date);
+        assert.instanceOf(stats.atime, Date);
+        if (process.getuid) {
+          assert.isNumber(stats.uid);
+        } else {
+          assert.strictEqual(stats.uid, 0);
+        }
+        if (process.getgid) {
+          assert.isNumber(stats.gid);
+        } else {
+          assert.strictEqual(stats.gid, 0);
+        }
+        assert.equal(stats.nlink, 3);
+        assert.isNumber(stats.rdev);
+        done();
+      })
+      .catch(done);
   });
 
   it('promise provides directory stats with bigint', function (done) {
-    fs.promises.stat('/path', {bigint: true}).then(function (stats) {
-      assert.instanceOf(stats.ctime, Date);
-      assert.instanceOf(stats.mtime, Date);
-      assert.instanceOf(stats.atime, Date);
-      if (process.getuid) {
-        assert.equal(typeof stats.uid, 'bigint');
-      } else {
-        assert.strictEqual(stats.uid, 0n);
-      }
-      if (process.getgid) {
-        assert.equal(typeof stats.gid, 'bigint');
-      } else {
-        assert.strictEqual(stats.gid, 0n);
-      }
-      assert.equal(typeof stats.nlink, 'bigint');
-      assert.equal(typeof stats.rdev, 'bigint');
-      done();
-    }, done);
+    fs.promises
+      .stat('/path', {bigint: true})
+      .then(function (stats) {
+        assert.instanceOf(stats.ctime, Date);
+        assert.instanceOf(stats.mtime, Date);
+        assert.instanceOf(stats.atime, Date);
+        if (process.getuid) {
+          assert.equal(typeof stats.uid, 'bigint');
+        } else {
+          assert.strictEqual(stats.uid, 0n);
+        }
+        if (process.getgid) {
+          assert.equal(typeof stats.gid, 'bigint');
+        } else {
+          assert.strictEqual(stats.gid, 0n);
+        }
+        assert.equal(typeof stats.nlink, 'bigint');
+        assert.equal(typeof stats.rdev, 'bigint');
+        done();
+      })
+      .catch(done);
   });
 
   if (
@@ -351,11 +377,14 @@ describe('fs.stat(path, options, callback)', function () {
     });
 
     it('promise includes blocks and blksize in directory stats', function (done) {
-      fs.promises.stat('/path').then(function (stats) {
-        assert.isNumber(stats.blocks);
-        assert.isNumber(stats.blksize);
-        done();
-      }, done);
+      fs.promises
+        .stat('/path')
+        .then(function (stats) {
+          assert.isNumber(stats.blocks);
+          assert.isNumber(stats.blksize);
+          done();
+        })
+        .catch(done);
     });
   }
 });
@@ -403,7 +432,8 @@ describe('fs.fstat(fd, options, callback)', function () {
         assert.isTrue(stats.isFile());
         assert.equal(stats.size, 12);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('promise accepts a file descriptor for a file (r) with bigint', function (done) {
@@ -416,7 +446,8 @@ describe('fs.fstat(fd, options, callback)', function () {
         assert.isTrue(stats.isFile());
         assert.equal(typeof stats.size, 'bigint');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('accepts a file descriptor for a directory (r)', function (done) {
@@ -453,7 +484,8 @@ describe('fs.fstat(fd, options, callback)', function () {
         assert.isTrue(stats.isDirectory());
         assert.equal(stats.size, 1);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('promise accepts a file descriptor for a directory (r) with bigint', function (done) {
@@ -466,7 +498,8 @@ describe('fs.fstat(fd, options, callback)', function () {
         assert.isTrue(stats.isDirectory());
         assert.equal(typeof stats.size, 'bigint');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('fails for bad file descriptor', function (done) {

--- a/test/lib/fs.unlink.spec.js
+++ b/test/lib/fs.unlink.spec.js
@@ -40,10 +40,13 @@ describe('fs.unlink(path, callback)', function () {
   });
 
   it('promise deletes a file', function (done) {
-    fs.promises.unlink('file.txt').then(function () {
-      assert.isFalse(fs.existsSync('file.txt'));
-      done();
-    }, done);
+    fs.promises
+      .unlink('file.txt')
+      .then(function () {
+        assert.isFalse(fs.existsSync('file.txt'));
+        done();
+      })
+      .catch(done);
   });
 
   it('updates mtime of parent', function (done) {
@@ -61,12 +64,15 @@ describe('fs.unlink(path, callback)', function () {
 
   it('updates mtime of parent', function (done) {
     const oldTime = fs.statSync('dir2').mtime;
-    fs.promises.unlink('dir2/file').then(function () {
-      assert.isFalse(fs.existsSync('dir2/file'));
-      const newTime = fs.statSync('dir2').mtime;
-      assert.isTrue(newTime > oldTime);
-      done();
-    }, done);
+    fs.promises
+      .unlink('dir2/file')
+      .then(function () {
+        assert.isFalse(fs.existsSync('dir2/file'));
+        const newTime = fs.statSync('dir2').mtime;
+        assert.isTrue(newTime > oldTime);
+        done();
+      })
+      .catch(done);
   });
 
   it('fails for a directory', function (done) {
@@ -110,15 +116,18 @@ describe('fs.unlink(path, callback)', function () {
 
   it('promise respects previously opened file descriptors', function (done) {
     const fd = fs.openSync('file.txt', 'r');
-    fs.promises.unlink('file.txt').then(function () {
-      assert.isFalse(fs.existsSync('file.txt'));
-      // but we can still use fd to read
-      const buffer = Buffer.alloc(7);
-      const read = fs.readSync(fd, buffer, 0, 7);
-      assert.equal(read, 7);
-      assert.equal(String(buffer), 'content');
-      done();
-    }, done);
+    fs.promises
+      .unlink('file.txt')
+      .then(function () {
+        assert.isFalse(fs.existsSync('file.txt'));
+        // but we can still use fd to read
+        const buffer = Buffer.alloc(7);
+        const read = fs.readSync(fd, buffer, 0, 7);
+        assert.equal(read, 7);
+        assert.equal(String(buffer), 'content');
+        done();
+      })
+      .catch(done);
   });
 });
 

--- a/test/lib/fs.utimes-lutimes-futimes.spec.js
+++ b/test/lib/fs.utimes-lutimes-futimes.spec.js
@@ -76,7 +76,8 @@ describe('fs.utimes(path, atime, mtime, callback)', function () {
         assert.equal(stats.atime.getTime(), 100);
         assert.equal(stats.mtime.getTime(), 200);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('updates timestamps for a directory', function (done) {
@@ -92,12 +93,15 @@ describe('fs.utimes(path, atime, mtime, callback)', function () {
   });
 
   it('promise updates timestamps for a directory', function (done) {
-    fs.promises.utimes('dir', new Date(300), new Date(400)).then(function () {
-      const stats = fs.statSync('dir');
-      assert.equal(stats.atime.getTime(), 300);
-      assert.equal(stats.mtime.getTime(), 400);
-      done();
-    }, done);
+    fs.promises
+      .utimes('dir', new Date(300), new Date(400))
+      .then(function () {
+        const stats = fs.statSync('dir');
+        assert.equal(stats.atime.getTime(), 300);
+        assert.equal(stats.mtime.getTime(), 400);
+        done();
+      })
+      .catch(done);
   });
 
   it('fails for a bogus path', function (done) {
@@ -192,7 +196,8 @@ describe('fs.lutimes(path, atime, mtime, callback)', function () {
         assert.equal(stats.atime.getTime(), 100);
         assert.equal(stats.mtime.getTime(), 200);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('updates timestamps for a directory', function (done) {
@@ -208,12 +213,15 @@ describe('fs.lutimes(path, atime, mtime, callback)', function () {
   });
 
   it('promise updates timestamps for a directory', function (done) {
-    fs.promises.lutimes('dir', new Date(300), new Date(400)).then(function () {
-      const stats = fs.statSync('dir');
-      assert.equal(stats.atime.getTime(), 300);
-      assert.equal(stats.mtime.getTime(), 400);
-      done();
-    }, done);
+    fs.promises
+      .lutimes('dir', new Date(300), new Date(400))
+      .then(function () {
+        const stats = fs.statSync('dir');
+        assert.equal(stats.atime.getTime(), 300);
+        assert.equal(stats.mtime.getTime(), 400);
+        done();
+      })
+      .catch(done);
   });
 
   it('fails for a bogus path', function (done) {
@@ -366,7 +374,8 @@ describe('fs.futimes(fd, atime, mtime, callback)', function () {
         assert.equal(stats.atime.getTime(), 100);
         assert.equal(stats.mtime.getTime(), 200);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('updates timestamps for a directory', function (done) {
@@ -393,7 +402,8 @@ describe('fs.futimes(fd, atime, mtime, callback)', function () {
         assert.equal(stats.atime.getTime(), 300);
         assert.equal(stats.mtime.getTime(), 400);
         done();
-      }, done);
+      })
+      .catch(done);
   });
 });
 

--- a/test/lib/fs.write.spec.js
+++ b/test/lib/fs.write.spec.js
@@ -40,7 +40,8 @@ describe('fs.write(fd, buffer, offset, length, position, callback)', function ()
         assert.equal(result.buffer, buffer);
         assert.equal(String(fs.readFileSync('path/new-file.txt')), 'new file');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('writes a buffer to a file with implicit offset, length, position', function (done) {
@@ -69,7 +70,8 @@ describe('fs.write(fd, buffer, offset, length, position, callback)', function ()
         assert.equal(result.buffer, buffer);
         assert.equal(String(fs.readFileSync('path/new-file.txt')), 'new file');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('can write a portion of a buffer to a file', function (done) {
@@ -102,7 +104,8 @@ describe('fs.write(fd, buffer, offset, length, position, callback)', function ()
         assert.equal(result.buffer, buffer);
         assert.equal(String(fs.readFileSync('path/new-file.txt')), 'ew fi');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('can write a portion of a buffer to a file position', function (done) {
@@ -141,7 +144,8 @@ describe('fs.write(fd, buffer, offset, length, position, callback)', function ()
           'fiew fintent'
         );
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('can write a portion of a buffer to a file position and enlarge the file', function (done) {
@@ -180,7 +184,8 @@ describe('fs.write(fd, buffer, offset, length, position, callback)', function ()
           'file conew fi'
         );
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('can append to a file', function (done) {
@@ -219,7 +224,8 @@ describe('fs.write(fd, buffer, offset, length, position, callback)', function ()
           'file content more'
         );
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('fails if file not open for writing', function (done) {
@@ -335,7 +341,8 @@ describe('fs.write(fd, data[, position[, encoding]], callback)', function () {
         assert.equal(String(result.buffer), string);
         assert.equal(String(fs.readFileSync('path/new-file.txt')), 'new file');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('writes a string to a file with implicit position and encoding', function (done) {
@@ -368,7 +375,8 @@ describe('fs.write(fd, data[, position[, encoding]], callback)', function () {
         assert.equal(String(result.buffer), string);
         assert.equal(String(fs.readFileSync('path/new-file.txt')), 'new file');
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('can append to a file', function (done) {
@@ -404,7 +412,8 @@ describe('fs.write(fd, data[, position[, encoding]], callback)', function () {
           'file content more'
         );
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('can write to a position of a file', function (done) {
@@ -440,7 +449,8 @@ describe('fs.write(fd, data[, position[, encoding]], callback)', function () {
           'fil moretent'
         );
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('can write to a position of a file and enlarge it', function (done) {
@@ -476,7 +486,8 @@ describe('fs.write(fd, data[, position[, encoding]], callback)', function () {
           'file cont more'
         );
         done();
-      }, done);
+      })
+      .catch(done);
   });
 
   it('fails if file not open for writing', function (done) {

--- a/test/lib/fs.writeFile.spec.js
+++ b/test/lib/fs.writeFile.spec.js
@@ -27,10 +27,13 @@ describe('fs.writeFile(filename, data, [options], callback)', function () {
   });
 
   it('promise writes a string to a file', function (done) {
-    fs.promises.writeFile('dir/foo', 'bar').then(function () {
-      assert.equal(String(fs.readFileSync('dir/foo')), 'bar');
-      done();
-    }, done);
+    fs.promises
+      .writeFile('dir/foo', 'bar')
+      .then(function () {
+        assert.equal(String(fs.readFileSync('dir/foo')), 'bar');
+        done();
+      })
+      .catch(done);
   });
 
   it('updates mtime of parent directory', function (done) {
@@ -47,11 +50,14 @@ describe('fs.writeFile(filename, data, [options], callback)', function () {
 
   it('promise updates mtime of parent directory', function (done) {
     const oldTime = fs.statSync('dir').mtime;
-    fs.promises.writeFile('dir/foo', 'bar').then(function () {
-      const newTime = fs.statSync('dir').mtime;
-      assert.isTrue(newTime > oldTime);
-      done();
-    }, done);
+    fs.promises
+      .writeFile('dir/foo', 'bar')
+      .then(function () {
+        const newTime = fs.statSync('dir').mtime;
+        assert.isTrue(newTime > oldTime);
+        done();
+      })
+      .catch(done);
   });
 
   it('writes a buffer to a file', function (done) {
@@ -65,10 +71,13 @@ describe('fs.writeFile(filename, data, [options], callback)', function () {
   });
 
   it('promise writes a buffer to a file', function (done) {
-    fs.promises.writeFile('dir/foo', Buffer.from('bar')).then(function () {
-      assert.equal(String(fs.readFileSync('dir/foo')), 'bar');
-      done();
-    }, done);
+    fs.promises
+      .writeFile('dir/foo', Buffer.from('bar'))
+      .then(function () {
+        assert.equal(String(fs.readFileSync('dir/foo')), 'bar');
+        done();
+      })
+      .catch(done);
   });
 
   it('fails if directory does not exist', function (done) {


### PR DESCRIPTION
While working on
https://github.com/tschaub/mock-fs/blob/main/changelog.md#400 I noticed
that tests would timeout when some assertions failed because done was
never called.

```
promise.then(() => {
  assert(false)
  done()
}, done)
```

The issue is that `then` will only call one of it's two callbacks. The
onRejected function is not called when onFulfilled throws an error.

Switching to `.catch(done)` guarnatees the a rejected promise chain
marks the test as completed.