### PR TITLE
Ignore errors in fs.exists

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -1485,7 +1485,14 @@ Binding.prototype.exists = function (filepath, callback, ctx) {
 
   return maybeCallback(normalizeCallback(callback), ctx, this, function () {
     filepath = deBuffer(filepath);
-    const item = this._system.getItem(filepath);
+    let item;
+    try {
+      item = this._system.getItem(filepath);
+    } catch {
+      // ignore errors
+      // see https://github.com/nodejs/node/blob/v22.11.0/lib/fs.js#L255-L257
+      return false;
+    }
 
     if (item) {
       if (item instanceof SymbolicLink) {

--- a/test/lib/fs.exists.spec.js
+++ b/test/lib/fs.exists.spec.js
@@ -76,6 +76,13 @@ describe('fs.exists(path, callback)', function () {
       done();
     });
   });
+
+  it('calls with false for bogus path (III)', function (done) {
+    fs.exists(path.join('path', 'to', 'a.bin', 'foo'), function (exists) {
+      assert.isFalse(exists);
+      done();
+    });
+  });
 });
 
 describe('fs.existsSync(path)', function () {
@@ -122,5 +129,9 @@ describe('fs.existsSync(path)', function () {
 
   it('returns false for bogus path (II)', function () {
     assert.isFalse(fs.existsSync(path.join('nested', 'dir', 'none')));
+  });
+
+  it('returns false for a path beyond a file', function () {
+    assert.isFalse(fs.existsSync(path.join('path', 'to', 'a.bin', 'foo')));
   });
 });


### PR DESCRIPTION
Node's `fs.exists()` [never throws](https://github.com/nodejs/node/blob/v22.11.0/lib/fs.js#L273-L274). And the `fs.existsSync()` is called with `false` [on any errors](https://github.com/nodejs/node/blob/v22.11.0/lib/fs.js#L255-L257).

Fixes #400.
